### PR TITLE
Work around invalid octet string bug in some SNMP stacks

### DIFF
--- a/snimpy/basictypes.py
+++ b/snimpy/basictypes.py
@@ -37,7 +37,7 @@ from snimpy import mib
 PYTHON3 = sys.version_info >= (3, 0)
 if PYTHON3:
     ord2 = lambda x: x
-    chr2 = lambda x: bytes([x])
+    chr2 = lambda x: bytes([x & 0xff])
     unicode = str
     long = int
 else:


### PR DESCRIPTION
Hi,

  On some particular brand of switch i'm using there is what I suppose is a bug in their SNMP implementation, which causes it to generate OIDs made of large 32bits integers, where an octet string is expected.

  This causes snimpy to choke on it when trying to convert it to a python bytes object. Net-SNMP just truncates the integers to bytes when asked to convert to string, which happens to work in this case (the bogus integers are of the form 0xffffff00 + expected byte)

  I know this may be a dangerous change, but for me the easiest fix was to let snimpy perform the same truncation, with the enclosed patch. As far as I can tell it should not break existing code, but i will understand if you choose to reject it :)
