### PR TITLE
Add IPv6 support

### DIFF
--- a/snimpy/snmp.py
+++ b/snimpy/snmp.py
@@ -154,10 +154,21 @@ class Session(object):
             raise ValueError("unsupported SNMP version {0}".format(version))
 
         # Put transport stuff into self._transport
-        host, port = host.partition(":")[::2]
-        if not port:
-            port = 161
-        self._transport = cmdgen.UdpTransportTarget((host, int(port)))
+        if "[" in host and "]" in host:
+            fields = host.split("]")
+            host = fields[0].strip("[")
+            if len(fields) > 1 and ":" in fields[1]:
+                port = fields[1].strip(":")
+            else:
+                port = 161
+
+            self._transport = cmdgen.Udp6TransportTarget((host, int(port)))
+        else:
+            host, port = host.partition(":")[::2]
+            if not port:
+                port = 161
+
+            self._transport = cmdgen.UdpTransportTarget((host, int(port)))
 
         # Bulk stuff
         self.bulk = 40


### PR DESCRIPTION
This allows for host defintion using [ipv6]:port.

Due to host containing both the host and the port, we have to use []
which is the standard workaround for those cases using IPv6,
unfortunately that means caller scripts will have to be IPv6 aware too
if they want to accept standard arguments from say nagios (which doesn't
pass [] by default).

Signed-off-by: Stéphane Graber stgraber@ubuntu.com
