### PR TITLE
Fixed typo on usage documentation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -50,7 +50,8 @@ entities. For a scalar, getting and setting a value is a simple as::
 
 For a column, you get a dictionary-like interface::
 
-    for index in m.ifDescr: print repr(m.ifDescr[index])
+    for index in m.ifDescr: 
+	print repr(m.ifDescr[index])
     m.ifAdminStatus[3] = "down"
 
 If you want to group several write into a single request, you can do


### PR DESCRIPTION
```
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -50,7 +50,8 @@ entities. For a scalar, getting and setting a value is a simple as::

 For a column, you get a dictionary-like interface::

-    for index in m.ifDescr: print repr(m.ifDescr[index])
+    for index in m.ifDescr:
+       print repr(m.ifDescr[index])
     m.ifAdminStatus[3] = "down"
```
