### PR TITLE
Allow overriding the type of a node

### DIFF
--- a/snimpy/basictypes.py
+++ b/snimpy/basictypes.py
@@ -111,6 +111,12 @@ class Type(object):
             self._value = value
             self.entity = entity
 
+        if isinstance(self, String):
+            # Ensure that strings follow their format, if it is applied.
+            # This is safer and simpler than toOid, as it does not do
+            # additional validation.
+            self._toBytes()
+
         return self
 
     @classmethod
@@ -489,7 +495,7 @@ class String(StringOrOctetString, unicode):
                 if not mo:
                     raise ValueError("{0!r} cannot be parsed because it "
                                      "does not match format {1} at "
-                                     "index {i}".format(self._value, fmt, i))
+                                     "index {2}".format(self._value, fmt, i))
                 if format in ["o", "x", "d"]:
                     if format == "o":
                         r = int(mo.group("o"), 8)

--- a/tests/SNIMPY-MIB.mib
+++ b/tests/SNIMPY-MIB.mib
@@ -7,6 +7,8 @@ IMPORTS
     Counter32, mib-2                  FROM SNMPv2-SMI
     DisplayString, TEXTUAL-CONVENTION,
     PhysAddress, TruthValue           FROM SNMPv2-TC
+    InetAddressType, InetAddress,
+    InetAddressIPv4, InetAddressIPv6  FROM INET-ADDRESS-MIB
     IANAifType                        FROM IANAifType-MIB;
 
 
@@ -360,5 +362,59 @@ snimpyIndexInt OBJECT-TYPE
     DESCRIPTION
             "An integer of fixed size"
     ::= { snimpyIndexEntry 6 }
+
+-- A table indexed using InetAddresses
+
+snimpyInetAddressTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF SnimpyInetAddressEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A InetAddress table"
+    ::= { snimpyTables 4 }
+
+snimpyInetAddressEntry OBJECT-TYPE
+    SYNTAX      SnimpyInetAddressEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Entry for our complex table"
+    INDEX   { snimpyInetAddressType, snimpyInetAddress }
+    ::= { snimpyInetAddressTable 1 }
+
+SnimpyInetAddressEntry ::=
+    SEQUENCE {
+        snimpyInetAddressType        InetAddressType,
+        snimpyInetAddress            InetAddress,
+        snimpyInetAddressState       INTEGER
+    }
+
+snimpyInetAddressType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Address type identifier for snimpyInetAddress"
+    ::= { snimpyInetAddressEntry 1 }
+
+snimpyInetAddress OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Type dependent InetAddress"
+    ::= { snimpyInetAddressEntry 2 }
+
+snimpyInetAddressState OBJECT-TYPE
+    SYNTAX      INTEGER {
+                  up(1),
+                  down(2),
+                  testing(3)
+		}
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "State for the IP"
+    ::= { snimpyInetAddressEntry 3 }
 
 END


### PR DESCRIPTION
This enables handling context specific types like InetAddress, whose
interpretation is based on the value of an InetAddressType field. Also enforces
format checking when creating instances of basictypes.String and fixes a minor
bug in the exception thus raised.

For an example, see:
	tests/test_mib.py:testOverrideType

Test coverage improves from 85% to 86%. There are +26 statements, -5 missing,
with no change to excluded.

Tested:
$ tox --skip-missing-interpreters
...
SKIPPED:  py26: InterpreterNotFound: python2.6
  py27: commands succeeded
SKIPPED:  py33: InterpreterNotFound: python3.3
  py34: commands succeeded
SKIPPED:  pypy: InterpreterNotFound: pypy
  lint: commands succeeded
  doc: commands succeeded
  congratulations :)