### PR TITLE
Add mib.Node.typeName and mib.getByOid

### DIFF
--- a/snimpy/mib.py
+++ b/snimpy/mib.py
@@ -89,8 +89,27 @@ class Node(object):
             raise SMIException("unable to retrieve type of node")
         return target
 
-    @type.setter
-    def type(self, type_name):
+    @property
+    def typeName(self):
+        """Retrieves the name of the the node's current declared type
+        (not basic type).
+
+        :return: A string representing the current declared type,
+            suitable for assignment to type.setter.
+        """
+        if self._override_type:
+            t = self._override_type
+        else:
+            t = _smi.smiGetNodeType(self.node)
+
+        if t is None or t == ffi.NULL:
+            raise SMIException("unable to retrieve the declared type "
+                               "of the node '{}'".format(self.node.name))
+
+        return ffi.string(t.name)
+
+    @typeName.setter
+    def typeName(self, type_name):
         """Override the node's type to type_name from the same module.
         The new type must resolve to the same basictype.
 
@@ -125,8 +144,8 @@ class Node(object):
                                    ffi.string(declared_type.name),
                                    ffi.string(new_type.name)))
 
-    @type.deleter
-    def type(self):
+    @typeName.deleter
+    def typeName(self):
         """Clears the type override."""
         self._override_type = None
 

--- a/snimpy/mib.py
+++ b/snimpy/mib.py
@@ -458,6 +458,20 @@ def get(mib, name):
     return pnode(node)
 
 
+def getByOid(oid):
+    """Get a node by its OID.
+
+    :param oid: The OID as a tuple
+    :return: The requested MIB node (:class:`Node`)
+    """
+    node = _smi.smiGetNodeByOID(len(oid), oid)
+    if node == ffi.NULL:
+        raise SMIException("no node for {0}".format(
+            ".".join([str(o) for o in oid])))
+    pnode = _kind2object(node.nodekind)
+    return pnode(node)
+
+
 def _get_kind(mib, kind):
     """Get nodes of a given kind from a MIB.
 

--- a/snimpy/smi.py
+++ b/snimpy/smi.py
@@ -135,6 +135,7 @@ SmiNode     *smiGetElementNode(SmiElement *);
 SmiRange    *smiGetFirstRange(SmiType *);
 SmiRange    *smiGetNextRange(SmiRange *);
 SmiNode     *smiGetNode(SmiModule *, const char *);
+SmiNode     *smiGetNodeByOID(unsigned int oidlen, SmiSubid *);
 SmiNode     *smiGetFirstNode(SmiModule *, SmiNodekind);
 SmiNode     *smiGetNextNode(SmiNode *, SmiNodekind);
 SmiNode     *smiGetParentNode(SmiNode *);

--- a/snimpy/smi.py
+++ b/snimpy/smi.py
@@ -153,6 +153,7 @@ _SOURCE = """
 #include <smi.h>
 """
 
+
 def create_modulename(prefix, cdef_sources, source, sys_version=sys.version):
     """
     This is the same as CFFI's create modulename except we don't include the

--- a/tests/test_mib.py
+++ b/tests/test_mib.py
@@ -263,7 +263,7 @@ class TestMibSnimpy(unittest.TestCase):
         # Try overriding to IPv4 with a byte string name.
         addrtype = addrtype_attr.type(addrtype_attr, "ipv4")
         self.assertEqual(addrtype, "ipv4")
-        addr_attr.type = b"InetAddressIPv4"
+        addr_attr.typeName = b"InetAddressIPv4"
         ipv4 = u"127.0.0.1"
         ipv4_oid = (4, 127, 0, 0, 1)
 
@@ -279,7 +279,7 @@ class TestMibSnimpy(unittest.TestCase):
         # Try both IPv6 and non-bytes name.
         addrtype = addrtype_attr.type(addrtype_attr, "ipv6")
         self.assertEqual(addrtype, "ipv6")
-        addr_attr.type = u"InetAddressIPv6"
+        addr_attr.typeName = u"InetAddressIPv6"
         # Snimpy does not use leading zeroes.
         ipv6 = u'102:304:506:708:90a:b0c:d0e:f01'
         ipv6_oid = (16, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
@@ -295,7 +295,7 @@ class TestMibSnimpy(unittest.TestCase):
         self.assertEqual(addr.toOid(), ipv6_oid)
 
         # Try overriding back to the default.
-        del addr_attr.type
+        del addr_attr.typeName
         addr_len, addr = addr_attr.type.fromOid(addr_attr, ipv4_oid)
         self.assertEqual(bytes(addr), b"\x7f\0\0\1")
 
@@ -304,16 +304,29 @@ class TestMibSnimpy(unittest.TestCase):
         attr = table.index[1]
 
         # Value with the wrong type.
-        self.assertRaises(AttributeError, setattr, attr, "type", None)
+        self.assertRaises(AttributeError, setattr, attr, "typeName", None)
 
         # Unknown type.
-        self.assertRaises(mib.SMIException, setattr, attr, "type",
+        self.assertRaises(mib.SMIException, setattr, attr, "typeName",
                           "SomeUnknownType.kjgf")
 
         # Incompatible basetype.
-        self.assertRaises(mib.SMIException, setattr, attr, "type",
+        self.assertRaises(mib.SMIException, setattr, attr, "typeName",
                           "InetAddressType")
 
         # Parse error.
-        attr.type = "InetAddressIPv4"
+        attr.typeName = "InetAddressIPv4"
         self.assertRaises(ValueError, attr.type, attr, u"01:02:03:04")
+
+    def testTypeName(self):
+        """Check that we can get the current declared type name"""
+        table = mib.get("SNIMPY-MIB", "snimpyInetAddressTable")
+        attr = table.index[1]
+
+        self.assertEqual(attr.typeName, b"InetAddress")
+
+        attr.typeName = b"InetAddressIPv4"
+        self.assertEqual(attr.typeName, b"InetAddressIPv4")
+
+        attr.typeName = b"InetAddressIPv6"
+        self.assertEqual(attr.typeName, b"InetAddressIPv6")

--- a/tests/test_mib.py
+++ b/tests/test_mib.py
@@ -105,6 +105,29 @@ class TestMibSnimpy(unittest.TestCase):
             self.assertEqual(str(mib.get('SNIMPY-MIB', i)), i)
             self.assert_(isinstance(mib.get('SNIMPY-MIB', i), mib.Node))
 
+    def testGetByOid(self):
+        """Test that we can get all named attributes by OID."""
+        for i in self.scalars:
+            nodebyname = mib.get('SNIMPY-MIB', i)
+            self.assertEqual(str(mib.getByOid(nodebyname.oid)), i)
+            self.assert_(isinstance(mib.getByOid(nodebyname.oid), mib.Scalar))
+        for i in self.tables:
+            nodebyname = mib.get('SNIMPY-MIB', i)
+            self.assertEqual(str(mib.getByOid(nodebyname.oid)), i)
+            self.assert_(isinstance(mib.getByOid(nodebyname.oid), mib.Table))
+        for i in self.columns:
+            nodebyname = mib.get('SNIMPY-MIB', i)
+            self.assertEqual(str(mib.getByOid(nodebyname.oid)), i)
+            self.assert_(isinstance(mib.getByOid(nodebyname.oid), mib.Column))
+        for i in self.nodes:
+            nodebyname = mib.get('SNIMPY-MIB', i)
+            self.assertEqual(str(mib.getByOid(nodebyname.oid)), i)
+            self.assert_(isinstance(mib.getByOid(nodebyname.oid), mib.Node))
+
+    def testGetByOid_UnknownOid(self):
+        """Test that unknown OIDs raise an exception."""
+        self.assertRaises(mib.SMIException, mib.getByOid, (255,))
+
     def testTableColumnRelation(self):
         """Test that we can get the column from the table and vice-versa"""
         for i in self.tables:


### PR DESCRIPTION
I'm wondering if you think type's setter and deleter should be moved to typeName to provide cleaner semantics.