### PR TITLE
Make type overriding more flexible

### DIFF
--- a/snimpy/mib.py
+++ b/snimpy/mib.py
@@ -110,7 +110,7 @@ class Node(object):
 
     @typeName.setter
     def typeName(self, type_name):
-        """Override the node's type to type_name from the same module.
+        """Override the node's type to type_name, found using _getType.
         The new type must resolve to the same basictype.
 
         :param type_name: string name of the type.
@@ -120,17 +120,10 @@ class Node(object):
         declared_type = _smi.smiGetNodeType(self.node)
         declared_basetype = self.type
 
-        module = _smi.smiGetTypeModule(declared_type)
-        if module == ffi.NULL:
-            raise SMIException("unable to get module for {0}".format(
-                self.node.name))
-
-        if not isinstance(type_name, bytes):
-            type_name = type_name.encode("ascii")
-        new_type = _smi.smiGetType(module, type_name)
-        if new_type == ffi.NULL:
-            raise SMIException("no type named {1} in module {0}".format(
-                ffi.string(module.name), type_name))
+        new_type = _getType(type_name)
+        if not new_type:
+            raise SMIException("no type named {0} in any loaded module".format(
+                type_name))
 
         # Easiest way to find the new basetype is to set the override
         # and ask.

--- a/snimpy/mib.py
+++ b/snimpy/mib.py
@@ -472,6 +472,21 @@ def getByOid(oid):
     return pnode(node)
 
 
+def _getType(type_name):
+    """Searches for a smi type through all loaded modules.
+
+    :param type_name: The name of the type to search for.
+    :return: The requested type (:class:`smi.SmiType`), if found, or None.
+    """
+    if not isinstance(type_name, bytes):
+        type_name = type_name.encode("ascii")
+    for module in _loadedModules():
+        new_type = _smi.smiGetType(module, type_name)
+        if new_type != ffi.NULL:
+            return new_type
+    return None
+
+
 def _get_kind(mib, kind):
     """Get nodes of a given kind from a MIB.
 

--- a/snimpy/mib.py
+++ b/snimpy/mib.py
@@ -102,6 +102,10 @@ class Node(object):
         else:
             t = _smi.smiGetNodeType(self.node)
 
+        # This occurs when the type is "implied".
+        if t.name == ffi.NULL:
+            t = _smi.smiGetParentType(t)
+
         if t is None or t == ffi.NULL:
             raise SMIException("unable to retrieve the declared type "
                                "of the node '{}'".format(self.node.name))

--- a/snimpy/mib.py
+++ b/snimpy/mib.py
@@ -550,4 +550,26 @@ def load(mib):
                            "(check with smilint -s -l1)".format(mib))
     return modulename
 
+
+def _loadedModules():
+    """Generates the list of loaded modules.
+
+    :yield: The :class:`smi.SmiModule` of all currently loaded modules.
+    """
+    module = _smi.smiGetFirstModule()
+    while module != ffi.NULL:
+        yield module
+
+        module = _smi.smiGetNextModule(module)
+
+
+def loadedMibNames():
+    """Generates the list of loaded MIB names.
+
+    :yield: The names of all currently loaded MIBs.
+    """
+    for module in _loadedModules():
+        yield ffi.string(module.name).decode('utf-8')
+
+
 reset()

--- a/snimpy/smi.py
+++ b/snimpy/smi.py
@@ -122,6 +122,8 @@ void         smiExit(void);
 void         smiSetErrorLevel(int);
 void         smiSetFlags(int);
 char        *smiLoadModule(const char *);
+SmiModule   *smiGetFirstModule();
+SmiModule   *smiGetNextModule(SmiModule *);
 SmiModule   *smiGetModule(const char *);
 SmiModule   *smiGetNodeModule(SmiNode *);
 SmiType     *smiGetNodeType(SmiNode *);

--- a/tests/SNIMPY-MIB.mib
+++ b/tests/SNIMPY-MIB.mib
@@ -193,7 +193,7 @@ snimpySimpleEntry OBJECT-TYPE
 
 SnimpySimpleEntry ::=
     SEQUENCE {
-        snimpySimpleIndex	Integer32,
+        snimpySimpleIndex       Integer32,
         snimpySimpleDescr       DisplayString,
         snimpySimpleType        IANAifType,
         snimpySimplePhys        PhysAddress

--- a/tests/test_mib.py
+++ b/tests/test_mib.py
@@ -135,6 +135,14 @@ class TestMibSnimpy(unittest.TestCase):
         """Test that unknown OIDs raise an exception."""
         self.assertRaises(mib.SMIException, mib.getByOid, (255,))
 
+    def testGetType(self):
+        """Test that _getType properly identifies known and unknown types."""
+        self.assertEqual(b"PhysAddress",
+                         mib.ffi.string(mib._getType("PhysAddress").name))
+        self.assertEqual(b"InetAddress",
+                         mib.ffi.string(mib._getType(b"InetAddress").name))
+        self.assertEqual(None, mib._getType("SomeUnknownType.kjgf"))
+
     def testTableColumnRelation(self):
         """Test that we can get the column from the table and vice-versa"""
         for i in self.tables:

--- a/tests/test_mib.py
+++ b/tests/test_mib.py
@@ -381,3 +381,6 @@ class TestMibSnimpy(unittest.TestCase):
 
         attr.typeName = b"InetAddressIPv6"
         self.assertEqual(attr.typeName, b"InetAddressIPv6")
+
+        attr = mib.get("SNIMPY-MIB", "snimpySimpleIndex")
+        self.assertEqual(attr.typeName, b"Integer32")

--- a/tests/test_mib.py
+++ b/tests/test_mib.py
@@ -52,6 +52,13 @@ class TestMibSnimpy(unittest.TestCase):
                         "snimpyMacAddress"]
         self.scalars.sort()
 
+        self.expected_modules = ["SNMPv2-SMI",
+                                 "SNMPv2-TC",
+                                 "SNMPv2-CONF",
+                                 "SNIMPY-MIB",
+                                 "INET-ADDRESS-MIB",
+                                 "IANAifType-MIB"]
+
     def tearDown(self):
         mib.reset()
 
@@ -251,6 +258,10 @@ class TestMibSnimpy(unittest.TestCase):
                 }
         for o in oids:
             self.assertEqual(mib.get('SNIMPY-MIB', o).oid, oids[o])
+
+    def testLoadedMibNames(self):
+        """Check that only expected modules were loaded."""
+        self.assertEqual(list(mib.loadedMibNames()), self.expected_modules)
 
     def testLoadInexistantModule(self):
         """Check that we get an exception when loading an inexistant module"""

--- a/tests/test_mib.py
+++ b/tests/test_mib.py
@@ -336,6 +336,15 @@ class TestMibSnimpy(unittest.TestCase):
         self.assertEqual(str(addr), ipv6)
         self.assertEqual(addr.toOid(), ipv6_oid)
 
+        # Try a type from a different module (chosen because snmpwalk
+        # prints IPv6 addresses incorrectly).
+        ipv6_1xformat = u'1:2:3:4:5:6:7:8:9:a:b:c:d:e:f:1'
+        addr_attr.typeName = "PhysAddress"
+
+        addr = addr_attr.type(addr_attr, ipv6_1xformat)
+        self.assertEqual(str(addr), ipv6_1xformat)
+        self.assertEqual(addr.toOid(), ipv6_oid)
+
         # Try overriding back to the default.
         del addr_attr.typeName
         addr_len, addr = addr_attr.type.fromOid(addr_attr, ipv4_oid)


### PR DESCRIPTION
This is my first attempt at removing the same-module restriction from mib.Node.typeName's setter.

I opted for adding the ability to iterate over the modules loaded into libsmi to avoid mib depending on manager having the complete set of loaded modules. It should also be more efficient as _getType doesn't need to repeatedly map the MIB names to SmiModules.

Let me know what you think!