### PR TITLE
Added a way to specify a partial key filter in walks

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -61,6 +61,17 @@ retrieve the values. This could be avoided with::
     for index, value in m.ifDescr.iteritems():
 	print(repr(value))
 
+Furthermore, you can pass partial index values to `iteritems()` to
+limit walked table rows to a specific subset::
+
+    for index, value in m.ipNetToMediaPhysAddress.iteritems(10):
+	print(repr(value))
+
+You can use subscript operator for this as well::
+
+    for index, value in m.ipNetToMediaPhysAddress[10]:
+	print(repr(value))
+
 Another way to avoid those extra SNMP requests is to enable the
 caching mechanism which is disabled by default::
 

--- a/snimpy/manager.py
+++ b/snimpy/manager.py
@@ -406,19 +406,33 @@ class ProxyIter(Proxy, Sized, Iterable, Container):
     def __len__(self):
         len(list(self.iteritems()))
 
-    def iteritems(self):
+    def iteritems(self, table_filter=None):
         count = 0
         oid = self.proxy.oid
         indexes = self.proxy.table.index
 
+        if table_filter is not None:
+            # Allow single-part table filter to be specified as is
+            if not isinstance(table_filter, tuple):
+                table_filter = (table_filter,)
+            if len(table_filter) >= len(indexes):
+                raise ValueError("Table filter has too many elements")
+            oid_suffix = []
+            # Convert filter elements to correct types
+            for i, part in enumerate(table_filter):
+                part = indexes[i].type(indexes[i], part, raw=False)
+                oid_suffix.extend(part.toOid())
+            oid += tuple(oid_suffix)
+
+        walk_oid = oid
         for noid, result in self.session.walk(oid):
             if noid <= oid:
                 noid = None
                 break
             oid = noid
-            if not((len(oid) >= len(self.proxy.oid) and
-                    oid[:len(self.proxy.oid)] ==
-                    self.proxy.oid[:len(self.proxy.oid)])):
+            if not((len(oid) >= len(walk_oid) and
+                    oid[:len(walk_oid)] ==
+                    walk_oid[:len(walk_oid)])):
                 noid = None
                 break
 
@@ -489,6 +503,15 @@ class ProxyColumn(ProxyIter, MutableMapping):
         self._loose = loose
 
     def __getitem__(self, index):
+        # If supplied index is partial we return a generator
+        idx_len = len(self.proxy.table.index)
+        if isinstance(index, tuple):
+            if len(index) < idx_len:
+                return (k for k, _ in self.iteritems(index))
+        elif idx_len > 1:
+            return (k for k, _ in self.iteritems(index))
+
+        # Otherwise a read op is made
         return self._op("get", index)
 
     def __setitem__(self, index, value):

--- a/snimpy/manager.py
+++ b/snimpy/manager.py
@@ -180,6 +180,15 @@ class Manager(object):
         >>> for idx in m.ifDescr:
         ...     print(m.ifDescr[idx])
 
+    You can get a slice of value indexes from a table by iterating on
+    a row name subscripted by a partial index::
+
+        >>> load("IF-MIB")
+        >>> m = Manager("localhost", "private")
+        >>> for idx in m.ipNetToMediaPhysAddress[1]:
+        ...     print(idx)
+        (<Integer: 1>, <IpAddress: 127.0.0.1>)
+
     A context manager is also provided. Any modification issued inside
     the context will be delayed until the end of the context and then
     grouped into a single SNMP PDU to be executed atomically::

--- a/tests/agent.py
+++ b/tests/agent.py
@@ -175,7 +175,8 @@ class TestAgent(object):
             ifIndex=MibTableColumn((1, 3, 6, 1, 2, 1, 2, 2, 1, 1),
                                    v2c.Integer()),
             # IF-MIB::ifRcvAddressAddress
-            ifRcvAddressAddress=MibTableColumn((1, 3, 6, 1, 2, 1, 31, 1, 4, 1, 1),
+            ifRcvAddressAddress=MibTableColumn((1, 3, 6, 1, 2, 1, 31,
+                                                1, 4, 1, 1),
                                                v2c.OctetString()))
 
         args = (

--- a/tests/agent.py
+++ b/tests/agent.py
@@ -142,9 +142,41 @@ class TestAgent(object):
                 (1, 3, 6, 1, 2, 1, 2, 2, 1, 10), (2,), v2c.Gauge32()),
             RandomMibScalarInstance(
                 (1, 3, 6, 1, 2, 1, 2, 2, 1, 10), (3,), v2c.Gauge32()),
+
+            # IF-MIB::ifRcvAddressTable
+            MibTable((1, 3, 6, 1, 2, 1, 31, 1, 4)),
+            MibTableRow((1, 3, 6, 1, 2, 1, 31, 1, 4, 1)).setIndexNames(
+                (0, '__MY_IF_MIB', 'ifIndex'),
+                (1, '__MY_IF_MIB', 'ifRcvAddressAddress')),
+            # IF-MIB::ifRcvAddressStatus
+            MibTableColumn((1, 3, 6, 1, 2, 1, 31, 1, 4, 1, 2), v2c.Integer()),
+            MibScalarInstance(
+                (1, 3, 6, 1, 2, 1, 31, 1, 4, 1, 2),
+                flatten(2, 6, stringToOid("abcdef")), v2c.Integer(1)),
+            MibScalarInstance(
+                (1, 3, 6, 1, 2, 1, 31, 1, 4, 1, 2),
+                flatten(2, 6, stringToOid("ghijkl")), v2c.Integer(1)),
+            MibScalarInstance(
+                (1, 3, 6, 1, 2, 1, 31, 1, 4, 1, 2),
+                flatten(3, 6, stringToOid("mnopqr")), v2c.Integer(1)),
+            # IF-MIB::ifRcvAddressType
+            MibTableColumn((1, 3, 6, 1, 2, 1, 31, 1, 4, 1, 3), v2c.Integer()),
+            MibScalarInstance(
+                (1, 3, 6, 1, 2, 1, 31, 1, 4, 1, 3),
+                flatten(2, 6, stringToOid("abcdef")), v2c.Integer(1)),
+            MibScalarInstance(
+                (1, 3, 6, 1, 2, 1, 31, 1, 4, 1, 3),
+                flatten(2, 6, stringToOid("ghijkl")), v2c.Integer(1)),
+            MibScalarInstance(
+                (1, 3, 6, 1, 2, 1, 31, 1, 4, 1, 3),
+                flatten(3, 6, stringToOid("mnopqr")), v2c.Integer(1)),
+
             # IF-MIB::ifIndex
             ifIndex=MibTableColumn((1, 3, 6, 1, 2, 1, 2, 2, 1, 1),
-                                   v2c.Integer()))
+                                   v2c.Integer()),
+            # IF-MIB::ifRcvAddressAddress
+            ifRcvAddressAddress=MibTableColumn((1, 3, 6, 1, 2, 1, 31, 1, 4, 1, 1),
+                                               v2c.OctetString()))
 
         args = (
             '__MY_SNIMPY-MIB',

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -146,6 +146,25 @@ class TestManagerGet(TestManager):
                           (("row3", (120, 1, 2, 3),
                             "gamma7", "end of row3"), 4110)])
 
+    def testWalkPartialIndexes(self):
+        """Test if we can walk a slice of a table given a partial index"""
+        results = [(idx, self.manager.ifRcvAddressType[idx])
+                   for idx in self.manager.ifRcvAddressStatus[2]]
+        self.assertEqual(results,
+                         [((2, "61:62:63:64:65:66"), 1),
+                          ((2, "67:68:69:6a:6b:6c"), 1)])
+        results = [(idx, self.manager.ifRcvAddressType[idx])
+                   for idx in self.manager.ifRcvAddressStatus[(3,)]]
+        self.assertEqual(results,
+                         [((3, "6d:6e:6f:70:71:72"), 1)])
+
+    def testWalkInvalidPartialIndexes(self):
+        """Try to get a table slice with an incorrect index filter"""
+        self.assertRaises(ValueError,
+                          lambda: list(
+                              self.manager.ifRcvAddressStatus.iteritems(
+                                  (3, "6d:6e:6f:70:71:72"))))
+
     def testGetInexistentStuff(self):
         """Try to access stuff that does not exist on the agent"""
         self.assertRaises(snmp.SNMPNoSuchObject,


### PR DESCRIPTION
This allows to efficiently retrieve parts of very large tables
when doing bulk reads, i.e.:
```
host.ipNetToMediaPhysAddress.iteritems(ifIndex)
```
It is rather crude, and abuses existing API (iteritems). You can suggest a different approach instead.