### PR TITLE
Ignore non ascii characters. Bad SNMP Agents might return them.

### DIFF
--- a/snimpy/basictypes.py
+++ b/snimpy/basictypes.py
@@ -451,7 +451,7 @@ class String(StringOrOctetString, unicode):
                     else:       # format == "d":
                         result += str(number)
                 elif format == "a":
-                    result += bb.decode("ascii")
+                    result += bb.decode("ascii", "ignore")
                 elif format == "t":
                     result += bb.decode("utf-8")
                 else:


### PR DESCRIPTION
There are some snmp agents around that return latin1 encoded strings. 