### PR TITLE
Partial indexes v2

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -67,10 +67,10 @@ limit walked table rows to a specific subset::
     for index, value in m.ipNetToMediaPhysAddress.iteritems(10):
 	print(repr(value))
 
-You can use subscript operator for this as well::
+If you don't need values you can use subscript syntax for this as well::
 
-    for index, value in m.ipNetToMediaPhysAddress[10]:
-	print(repr(value))
+    for index in m.ipNetToMediaPhysAddress[10]:
+	print(repr(index))
 
 Another way to avoid those extra SNMP requests is to enable the
 caching mechanism which is disabled by default::

--- a/snimpy/manager.py
+++ b/snimpy/manager.py
@@ -180,7 +180,7 @@ class Manager(object):
         >>> for idx in m.ifDescr:
         ...     print(m.ifDescr[idx])
 
-    You can get a slice of value indexes from a table by iterating on
+    You can get a slice of index values from a table by iterating on
     a row name subscripted by a partial index::
 
         >>> load("IF-MIB")
@@ -188,6 +188,17 @@ class Manager(object):
         >>> for idx in m.ipNetToMediaPhysAddress[1]:
         ...     print(idx)
         (<Integer: 1>, <IpAddress: 127.0.0.1>)
+
+    You can use multivalue indexes in two ways: using Pythonic
+    multi-dimensional dict syntax, or by providing a tuple containing
+    index values::
+
+        >>> load("IF-MIB")
+        >>> m = Manager("localhost", "private")
+        >>> m.ipNetToMediaPhysAddress[1]['127.0.0.1']
+        <String: aa:bb:cc:dd:ee:ff>
+        >>> m.ipNetToMediaPhysAddress[(1, '127.0.0.1')]
+        <String: aa:bb:cc:dd:ee:ff>
 
     A context manager is also provided. Any modification issued inside
     the context will be delayed until the end of the context and then

--- a/snimpy/manager.py
+++ b/snimpy/manager.py
@@ -197,7 +197,7 @@ class Manager(object):
         >>> m = Manager("localhost", "private")
         >>> m.ipNetToMediaPhysAddress[1]['127.0.0.1']
         <String: aa:bb:cc:dd:ee:ff>
-        >>> m.ipNetToMediaPhysAddress[(1, '127.0.0.1')]
+        >>> m.ipNetToMediaPhysAddress[1, '127.0.0.1']
         <String: aa:bb:cc:dd:ee:ff>
 
     A context manager is also provided. Any modification issued inside

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -94,6 +94,14 @@ class TestManagerGet(TestManager):
         """Retrieve MacAddress as a scalar"""
         self.scalarGetAndCheck("snimpyMacAddress", "11:12:13:14:15:16")
 
+    def testContains_IfDescr(self):
+        """Test proxy column membership checking code"""
+        self.assertEqual(2 in self.manager.ifDescr,
+                         True)
+        # FIXME: this currently fails under TestManagerWithNone
+        # self.assertEqual(10 in self.manager.ifDescr,
+        #                 False)
+
     def testWalkIfDescr(self):
         """Test we can walk IF-MIB::ifDescr and IF-MIB::ifTpe"""
         results = [(idx, self.manager.ifDescr[idx], self.manager.ifType[idx])
@@ -157,6 +165,9 @@ class TestManagerGet(TestManager):
                    for idx in self.manager.ifRcvAddressStatus[(3,)]]
         self.assertEqual(results,
                          [((3, "6d:6e:6f:70:71:72"), 1)])
+        results = list(self.manager.ifRcvAddressType.iteritems(3))
+        self.assertEqual(results,
+                         [((3, "6d:6e:6f:70:71:72"), 1)])
 
     def testWalkInvalidPartialIndexes(self):
         """Try to get a table slice with an incorrect index filter"""
@@ -164,6 +175,22 @@ class TestManagerGet(TestManager):
                           lambda: list(
                               self.manager.ifRcvAddressStatus.iteritems(
                                   (3, "6d:6e:6f:70:71:72"))))
+
+    def testContains_Partial(self):
+        """Test proxy column membership checking code with partial indexes"""
+        self.assertEqual(
+                "61:62:63:64:65:66" in self.manager.ifRcvAddressStatus[2],
+                True)
+        # FIXME: this currently fails under TestManagerWithNone
+        # self.assertEqual(
+        #        "6d:6e:6f:70:71:72" in self.manager.ifRcvAddressStatus[2],
+        #        False)
+
+    def testScalar_MultipleSubscripts(self):
+        """Retrieve a scalar value using multiple subscript syntax
+        (attr[x][y])"""
+        self.assertEqual(self.manager.ifRcvAddressType[2]["67:68:69:6a:6b:6c"],
+                         1)
 
     def testGetInexistentStuff(self):
         """Try to access stuff that does not exist on the agent"""


### PR DESCRIPTION
Refactored partial indexes. Now ```ProxyColumn``` stores its OID suffix internally. This allows for:
 * Multiple nested dict syntax: ```attr[val1][val2]```
 * ```iteritems()``` on any level with additional filters: ```attr[val1].iteritems()```
 * Old-style partial indexes via ```.iteritems(val)``` are still supported.

Fixes #50 