### PR TITLE
Change IPV6 regex to take letters into account. Correcting issue #53

### DIFF
--- a/snimpy/snmp.py
+++ b/snimpy/snmp.py
@@ -175,7 +175,7 @@ class Session(object):
 
         # Put transport stuff into self._transport
         mo = re.match(r'^(?:'
-                      r'\[(?P<ipv6>[\d:]+)\]|'
+                      r'\[(?P<ipv6>[\d:A-Fa-f]+)\]|'
                       r'(?P<ipv4>[\d\.]+)|'
                       r'(?P<any>.*?))'
                       r'(?::(?P<port>\d+))?$',


### PR DESCRIPTION
As discussed in the issue #53, here is the regex for IPV6 addresses.