### PR TITLE
snmp: ability to specify SNMPv3 context name

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 +++++++++++++++++++
 
  * Support for more recent versions of IPython.
+ * Support for SNMPv3 context name.
 
 0.8.11 (2016-08-13)
 +++++++++++++++++++

--- a/snimpy/manager.py
+++ b/snimpy/manager.py
@@ -233,7 +233,8 @@ class Manager(object):
                  # SNMPv3
                  secname=None,
                  authprotocol=None, authpassword=None,
-                 privprotocol=None, privpassword=None):
+                 privprotocol=None, privpassword=None,
+                 contextname=None):
         """Create a new SNMP manager. Some of the parameters are explained in
         :meth:`snmp.Session.__init__`.
 
@@ -278,6 +279,7 @@ class Manager(object):
                                      secname,
                                      authprotocol, authpassword,
                                      privprotocol, privpassword,
+                                     contextname=contextname,
                                      bulk=bulk)
         if timeout is not None:
             self._session.timeout = int(timeout * 1000000)

--- a/tests/test_snmp.py
+++ b/tests/test_snmp.py
@@ -401,6 +401,21 @@ class TestSnmp3(TestSnmp2):
                     privpassword="{0}-privpass".format(password))
 
 
+class TestSnmp3AndContext(TestSnmp3):
+
+    """Test communicaton with an agent with SNMPv3 and a context"""
+
+    def setUpSession(self, agent, password):
+        return dict(host="127.0.0.1:{0}".format(agent.port),
+                    version=3,
+                    secname="read-write",
+                    authprotocol="MD5",
+                    authpassword="{0}-authpass".format(password),
+                    privprotocol="AES",
+                    privpassword="{0}-privpass".format(password),
+                    contextname="batman")
+
+
 class TestSnmpTransports(unittest.TestCase):
 
     """Test communication using IPv6."""


### PR DESCRIPTION
Fix #65