### PR TITLE
Add isolated MIB loaders to support multiple sets of MIBs

### DIFF
--- a/tests/SNIMPY2-MIB.mib
+++ b/tests/SNIMPY2-MIB.mib
@@ -1,0 +1,511 @@
+SNIMPY2-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE,
+    IpAddress, Integer32, Gauge32,
+    TimeTicks, Counter64,
+    Counter32, mib-2                  FROM SNMPv2-SMI
+    DisplayString, TEXTUAL-CONVENTION,
+    PhysAddress, TruthValue           FROM SNMPv2-TC
+    InetAddressType, InetAddress,
+    InetAddressIPv4, InetAddressIPv6  FROM INET-ADDRESS-MIB
+    IANAifType                        FROM IANAifType-MIB;
+
+
+snimpy2 MODULE-IDENTITY
+    LAST-UPDATED "200809160000Z"
+    ORGANIZATION
+           "snimpy2
+            https://github.com/vincentbernat/snimpy"
+    CONTACT-INFO
+           "Lorem ipsum, etc, etc."
+    DESCRIPTION
+           "This is a test MIB module for snimpy MibLoader."
+
+    REVISION      "200809160000Z"
+    DESCRIPTION   "Last revision"
+    ::= { mib-2 45121 }
+
+OddInteger ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d-2"
+    STATUS       current
+    DESCRIPTION
+	"Testing fmt"
+    SYNTAX       INTEGER (6..18 | 20..23 | 27 | 28..1336)
+
+UnicodeString ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "255t"
+    STATUS       current
+    DESCRIPTION
+	"Testing fmt"
+    SYNTAX       OCTET STRING (SIZE(0..255))
+
+snimpy2Scalars OBJECT IDENTIFIER ::= { snimpy2 1 }
+snimpy2Tables  OBJECT IDENTIFIER ::= { snimpy2 2 }
+
+snimpy2IpAddress OBJECT-TYPE
+    SYNTAX 	IpAddress
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"An IP address"
+    ::= { snimpy2Scalars 1 }
+
+snimpy2String OBJECT-TYPE
+    SYNTAX 	DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"An string to display"
+    ::= { snimpy2Scalars 2 }
+
+snimpy2Integer OBJECT-TYPE
+    SYNTAX 	OddInteger
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"An integer"
+    ::= { snimpy2Scalars 3 }
+
+snimpy2Enum OBJECT-TYPE
+    SYNTAX      INTEGER {
+                  up(1),
+                  down(2),
+                  testing(3)
+                }
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"An enumeration"
+    ::= { snimpy2Scalars 4 }
+
+snimpy2ObjectId OBJECT-TYPE
+    SYNTAX      OBJECT IDENTIFIER
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"An oid"
+    ::= { snimpy2Scalars 5 }
+
+snimpy2Boolean OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"A boolean"
+    ::= { snimpy2Scalars 6 }
+
+snimpy2Counter OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"A 32 bits counter"
+    ::= { snimpy2Scalars 7 }
+
+snimpy2Gauge OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"A 32 bits gauge"
+    ::= { snimpy2Scalars 8 }
+
+snimpy2Timeticks OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"A timetick"
+    ::= { snimpy2Scalars 9 }
+
+snimpy2Counter64 OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"A 64-bit counter"
+    ::= { snimpy2Scalars 10 }
+
+snimpy2Bits	OBJECT-TYPE
+    SYNTAX	BITS {
+                  first(0),
+		  second(1),
+		  third(2),
+		  last(7)
+		}
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"A bit field"
+    ::= { snimpy2Scalars 11 }
+
+snimpy2NotImplemented OBJECT-TYPE
+    SYNTAX 	DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"An string to display (not implemented)"
+    ::= { snimpy2Scalars 12 }
+
+snimpy2OctetString OBJECT-TYPE
+    SYNTAX 	OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"An string to display"
+    ::= { snimpy2Scalars 13 }
+
+snimpy2UnicodeString OBJECT-TYPE
+    SYNTAX 	UnicodeString
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"An unicode string to display"
+    ::= { snimpy2Scalars 14 }
+
+snimpy2MacAddress OBJECT-TYPE
+    SYNTAX 	PhysAddress
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"A MAC address"
+    ::= { snimpy2Scalars 15 }
+
+snimpy2MacAddressInvalid OBJECT-TYPE
+    SYNTAX 	DisplayString
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+	"A MAC address with invalid syntax"
+    ::= { snimpy2Scalars 16 }
+
+-- A simple table
+
+snimpy2SimpleTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Snimpy2SimpleEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A table"
+    ::= { snimpy2Tables 1 }
+
+snimpy2SimpleEntry OBJECT-TYPE
+    SYNTAX      Snimpy2SimpleEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Entry for our simple table"
+    INDEX   { snimpy2SimpleIndex }
+    ::= { snimpy2SimpleTable 1 }
+
+Snimpy2SimpleEntry ::=
+    SEQUENCE {
+        snimpy2SimpleIndex       Integer32,
+        snimpy2SimpleDescr       DisplayString,
+        snimpy2SimpleType        IANAifType,
+        snimpy2SimplePhys        PhysAddress
+    }
+
+snimpy2SimpleIndex OBJECT-TYPE
+    SYNTAX      Integer32 (1..30)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Index for snimpy2 simple table"
+    ::= { snimpy2SimpleEntry 1 }
+
+snimpy2SimpleDescr OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "Blah blah"
+    ::= { snimpy2SimpleEntry 2 }
+
+snimpy2SimpleType OBJECT-TYPE
+    SYNTAX      IANAifType
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "Blah blah"
+    ::= { snimpy2SimpleEntry 3 }
+
+snimpy2SimplePhys OBJECT-TYPE
+    SYNTAX      PhysAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "Blah blah"
+    ::= { snimpy2SimpleEntry 4 }
+
+-- A more complex table
+
+snimpy2ComplexTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Snimpy2ComplexEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A more complex table"
+    ::= { snimpy2Tables 2 }
+
+snimpy2ComplexEntry OBJECT-TYPE
+    SYNTAX      Snimpy2ComplexEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Entry for our complex table"
+    INDEX   { snimpy2ComplexFirstIP, snimpy2ComplexSecondIP }
+    ::= { snimpy2ComplexTable 1 }
+
+Snimpy2ComplexEntry ::=
+    SEQUENCE {
+        snimpy2ComplexFirstIP	 IpAddress,
+        snimpy2ComplexSecondIP    IpAddress,
+        snimpy2ComplexState       INTEGER
+    }
+
+snimpy2ComplexFirstIP OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "First IP address for index"
+    ::= { snimpy2ComplexEntry 1 }
+
+snimpy2ComplexSecondIP OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Second IP address for index"
+    ::= { snimpy2ComplexEntry 2 }
+
+snimpy2ComplexState OBJECT-TYPE
+    SYNTAX      INTEGER {
+                  up(1),
+                  down(2),
+                  testing(3)
+		}
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+	"State for our both IP"
+    ::= { snimpy2ComplexEntry 3 }
+
+-- A table with complex indexes
+
+snimpy2IndexTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Snimpy2IndexEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A table with complex indexes"
+    ::= { snimpy2Tables 3 }
+
+snimpy2IndexEntry OBJECT-TYPE
+    SYNTAX      Snimpy2IndexEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Entry for our indexed table"
+    INDEX   { snimpy2IndexVarLen, snimpy2IndexOidVarLen,
+    	      snimpy2IndexFixedLen, IMPLIED snimpy2IndexImplied }
+    ::= { snimpy2IndexTable 1 }
+
+Snimpy2IndexEntry ::=
+    SEQUENCE {
+        snimpy2IndexVarLen	DisplayString,
+	snimpy2IndexIntIndex	Integer32,
+	snimpy2IndexOidVarLen	OBJECT IDENTIFIER,
+	snimpy2IndexFixedLen	DisplayString,
+        snimpy2IndexImplied      DisplayString,
+        snimpy2IndexInt          Integer32
+    }
+
+snimpy2IndexVarLen OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..10))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "Variable length index"
+    ::= { snimpy2IndexEntry 1 }
+
+snimpy2IndexIntIndex OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Integer index"
+    ::= { snimpy2IndexEntry 2 }
+
+snimpy2IndexOidVarLen OBJECT-TYPE
+    SYNTAX	OBJECT IDENTIFIER
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"OID as index"
+    ::= { snimpy2IndexEntry 3 }
+
+snimpy2IndexFixedLen OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (6))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Fixed length index"
+    ::= { snimpy2IndexEntry 4 }
+
+snimpy2IndexImplied OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (1..30))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Variable length index, implied"
+    ::= { snimpy2IndexEntry 5 }
+
+snimpy2IndexInt OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "An integer of fixed size"
+    ::= { snimpy2IndexEntry 6 }
+
+-- A table indexed using InetAddresses
+
+snimpy2InetAddressTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Snimpy2InetAddressEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A InetAddress table"
+    ::= { snimpy2Tables 4 }
+
+snimpy2InetAddressEntry OBJECT-TYPE
+    SYNTAX      Snimpy2InetAddressEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Entry for our complex table"
+    INDEX   { snimpy2InetAddressType, snimpy2InetAddress }
+    ::= { snimpy2InetAddressTable 1 }
+
+Snimpy2InetAddressEntry ::=
+    SEQUENCE {
+        snimpy2InetAddressType        InetAddressType,
+        snimpy2InetAddress            InetAddress,
+        snimpy2InetAddressState       INTEGER
+    }
+
+snimpy2InetAddressType OBJECT-TYPE
+    SYNTAX      InetAddressType
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Address type identifier for snimpy2InetAddress"
+    ::= { snimpy2InetAddressEntry 1 }
+
+snimpy2InetAddress OBJECT-TYPE
+    SYNTAX      InetAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Type dependent InetAddress"
+    ::= { snimpy2InetAddressEntry 2 }
+
+snimpy2InetAddressState OBJECT-TYPE
+    SYNTAX      INTEGER {
+                  up(1),
+                  down(2),
+                  testing(3)
+		}
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "State for the IP"
+    ::= { snimpy2InetAddressEntry 3 }
+
+-- A table that may contain invalid values
+
+snimpy2InvalidTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Snimpy2InvalidEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A table"
+    ::= { snimpy2Tables 5 }
+
+snimpy2InvalidEntry OBJECT-TYPE
+    SYNTAX      Snimpy2InvalidEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Entry for our invalid table"
+    INDEX   { snimpy2InvalidIndex }
+    ::= { snimpy2InvalidTable 1 }
+
+Snimpy2InvalidEntry ::=
+    SEQUENCE {
+        snimpy2InvalidIndex       Integer32,
+        snimpy2InvalidDescr       DisplayString
+    }
+
+snimpy2InvalidIndex OBJECT-TYPE
+    SYNTAX      Integer32 (1..30)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Index for snimpy2 invalid table"
+    ::= { snimpy2InvalidEntry 1 }
+
+snimpy2InvalidDescr OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "Blah blah"
+    ::= { snimpy2InvalidEntry 2 }
+
+-- A table that may be empty
+
+snimpy2EmptyTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF Snimpy2EmptyEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A table"
+    ::= { snimpy2Tables 6 }
+
+snimpy2EmptyEntry OBJECT-TYPE
+    SYNTAX      Snimpy2EmptyEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Entry for our empty table"
+    INDEX   { snimpy2EmptyIndex }
+    ::= { snimpy2EmptyTable 1 }
+
+Snimpy2EmptyEntry ::=
+    SEQUENCE {
+        snimpy2EmptyIndex       Integer32,
+        snimpy2EmptyDescr       DisplayString
+    }
+
+snimpy2EmptyIndex OBJECT-TYPE
+    SYNTAX      Integer32 (1..30)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Index for snimpy2 empty table"
+    ::= { snimpy2EmptyEntry 1 }
+
+snimpy2EmptyDescr OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE (0..255))
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "Blah blah"
+    ::= { snimpy2EmptyEntry 2 }
+
+
+END

--- a/tests/agent.py
+++ b/tests/agent.py
@@ -178,194 +178,198 @@ class TestAgent(object):
             ifRcvAddressAddress=MibTableColumn((1, 3, 6, 1, 2, 1, 31,
                                                 1, 4, 1, 1),
                                                v2c.OctetString()))
+        for m in ('snimpy', 'snimpy2'):
+            um = m.upper()
+            mymib = '__MY_{}-MIB'.format(um)
+            args = (
+                mymib,
+                # SNIMPY-MIB::snimpyIpAddress
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 1),
+                          v2c.OctetString()).setMaxAccess("readwrite"),
+                MibScalarInstance(
+                    (1, 3, 6, 1, 2, 1, 45121, 1, 1), (0,),
+                    v2c.OctetString("AAAA")),
+                # SNIMPY-MIB::snimpyString
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 2),
+                          v2c.OctetString()).setMaxAccess("readwrite"),
+                MibScalarInstance(
+                    (1, 3, 6, 1, 2, 1, 45121, 1, 2), (0,),
+                    v2c.OctetString("bye")),
+                # SNIMPY-MIB::snimpyInteger
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 3),
+                          v2c.Integer()).setMaxAccess("readwrite"),
+                MibScalarInstance(
+                    (1, 3, 6, 1, 2, 1, 45121, 1, 3), (0,), v2c.Integer(19)),
+                # SNIMPY-MIB::snimpyEnum
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 4),
+                          v2c.Integer()).setMaxAccess("readwrite"),
+                MibScalarInstance(
+                    (1, 3, 6, 1, 2, 1, 45121, 1, 4), (0,), v2c.Integer(2)),
+                # SNIMPY-MIB::snimpyObjectId
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 5),
+                          v2c.ObjectIdentifier()).setMaxAccess("readwrite"),
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 1, 5), (
+                    0,), v2c.ObjectIdentifier((1, 3, 6, 4454, 0, 0))),
+                # SNIMPY-MIB::snimpyBoolean
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 6),
+                          v2c.Integer()).setMaxAccess("readwrite"),
+                MibScalarInstance(
+                    (1, 3, 6, 1, 2, 1, 45121, 1, 6), (0,), v2c.Integer(1)),
+                # SNIMPY-MIB::snimpyCounter
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 7),
+                          v2c.Counter32()).setMaxAccess("readwrite"),
+                MibScalarInstance(
+                    (1, 3, 6, 1, 2, 1, 45121, 1, 7), (0,), v2c.Counter32(47)),
+                # SNIMPY-MIB::snimpyGauge
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 8),
+                          v2c.Gauge32()).setMaxAccess("readwrite"),
+                MibScalarInstance(
+                    (1, 3, 6, 1, 2, 1, 45121, 1, 8), (0,), v2c.Gauge32(18)),
+                # SNIMPY-MIB::snimpyTimeticks
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 9),
+                          v2c.TimeTicks()).setMaxAccess("readwrite"),
+                MibScalarInstance(
+                    (1, 3, 6, 1, 2, 1, 45121, 1, 9), (0,),
+                    v2c.TimeTicks(12111100)),
+                # SNIMPY-MIB::snimpyCounter64
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 10),
+                          v2c.Counter64()).setMaxAccess("readwrite"),
+                MibScalarInstance(
+                    (1, 3, 6, 1, 2, 1, 45121, 1, 10), (0,),
+                    v2c.Counter64(2 ** 48 + 3)),
+                # SNIMPY-MIB::snimpyBits
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 11),
+                          v2c.OctetString()).setMaxAccess("readwrite"),
+                MibScalarInstance(
+                    (1, 3, 6, 1, 2, 1, 45121, 1, 11), (0,),
+                    v2c.OctetString(b"\xa0")),
+                # SNIMPY-MIB::snimpyMacAddress
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 15),
+                          v2c.OctetString()).setMaxAccess("readwrite"),
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 1, 15), (
+                    0,), v2c.OctetString(b"\x11\x12\x13\x14\x15\x16")),
+                # SNIMPY-MIB::snimpyMacAddressInvalid
+                MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 16),
+                          v2c.OctetString()).setMaxAccess("readwrite"),
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 1, 16), (
+                    0,), v2c.OctetString(b"\xf1\x12\x13\x14\x15\x16")),
 
-        args = (
-            '__MY_SNIMPY-MIB',
-            # SNIMPY-MIB::snimpyIpAddress
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 1),
-                      v2c.OctetString()).setMaxAccess("readwrite"),
-            MibScalarInstance(
-                (1, 3, 6, 1, 2, 1, 45121, 1, 1), (0,),
-                v2c.OctetString("AAAA")),
-            # SNIMPY-MIB::snimpyString
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 2),
-                      v2c.OctetString()).setMaxAccess("readwrite"),
-            MibScalarInstance(
-                (1, 3, 6, 1, 2, 1, 45121, 1, 2), (0,), v2c.OctetString("bye")),
-            # SNIMPY-MIB::snimpyInteger
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 3),
-                      v2c.Integer()).setMaxAccess("readwrite"),
-            MibScalarInstance(
-                (1, 3, 6, 1, 2, 1, 45121, 1, 3), (0,), v2c.Integer(19)),
-            # SNIMPY-MIB::snimpyEnum
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 4),
-                      v2c.Integer()).setMaxAccess("readwrite"),
-            MibScalarInstance(
-                (1, 3, 6, 1, 2, 1, 45121, 1, 4), (0,), v2c.Integer(2)),
-            # SNIMPY-MIB::snimpyObjectId
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 5),
-                      v2c.ObjectIdentifier()).setMaxAccess("readwrite"),
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 1, 5), (
-                0,), v2c.ObjectIdentifier((1, 3, 6, 4454, 0, 0))),
-            # SNIMPY-MIB::snimpyBoolean
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 6),
-                      v2c.Integer()).setMaxAccess("readwrite"),
-            MibScalarInstance(
-                (1, 3, 6, 1, 2, 1, 45121, 1, 6), (0,), v2c.Integer(1)),
-            # SNIMPY-MIB::snimpyCounter
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 7),
-                      v2c.Counter32()).setMaxAccess("readwrite"),
-            MibScalarInstance(
-                (1, 3, 6, 1, 2, 1, 45121, 1, 7), (0,), v2c.Counter32(47)),
-            # SNIMPY-MIB::snimpyGauge
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 8),
-                      v2c.Gauge32()).setMaxAccess("readwrite"),
-            MibScalarInstance(
-                (1, 3, 6, 1, 2, 1, 45121, 1, 8), (0,), v2c.Gauge32(18)),
-            # SNIMPY-MIB::snimpyTimeticks
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 9),
-                      v2c.TimeTicks()).setMaxAccess("readwrite"),
-            MibScalarInstance(
-                (1, 3, 6, 1, 2, 1, 45121, 1, 9), (0,),
-                v2c.TimeTicks(12111100)),
-            # SNIMPY-MIB::snimpyCounter64
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 10),
-                      v2c.Counter64()).setMaxAccess("readwrite"),
-            MibScalarInstance(
-                (1, 3, 6, 1, 2, 1, 45121, 1, 10), (0,),
-                v2c.Counter64(2 ** 48 + 3)),
-            # SNIMPY-MIB::snimpyBits
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 11),
-                      v2c.OctetString()).setMaxAccess("readwrite"),
-            MibScalarInstance(
-                (1, 3, 6, 1, 2, 1, 45121, 1, 11), (0,),
-                v2c.OctetString(b"\xa0")),
-            # SNIMPY-MIB::snimpyMacAddress
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 15),
-                      v2c.OctetString()).setMaxAccess("readwrite"),
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 1, 15), (
-                0,), v2c.OctetString(b"\x11\x12\x13\x14\x15\x16")),
-            # SNIMPY-MIB::snimpyMacAddressInvalid
-            MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 16),
-                      v2c.OctetString()).setMaxAccess("readwrite"),
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 1, 16), (
-                0,), v2c.OctetString(b"\xf1\x12\x13\x14\x15\x16")),
-
-            # SNIMPY-MIB::snimpyIndexTable
-            MibTable((1, 3, 6, 1, 2, 1, 45121, 2, 3)),
-            MibTableRow(
-                (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1)).setIndexNames(
-                (0, "__MY_SNIMPY-MIB", "snimpyIndexVarLen"),
-                (0, "__MY_SNIMPY-MIB", "snimpyIndexOidVarLen"),
-                (0, "__MY_SNIMPY-MIB", "snimpyIndexFixedLen"),
-                (1, "__MY_SNIMPY-MIB", "snimpyIndexImplied")),
-            # SNIMPY-MIB::snimpyIndexVarLen
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 1),
-                              flatten(4, stringToOid('row1'),
-                                      3, 1, 2, 3,
-                                      stringToOid('alpha5'),
-                                      stringToOid('end of row1')),
-                              v2c.OctetString(b"row1")),
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 1),
-                              flatten(4, stringToOid('row2'),
-                                      4, 1, 0, 2, 3,
-                                      stringToOid('beta32'),
-                                      stringToOid('end of row2')),
-                              v2c.OctetString(b"row2")),
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 1),
-                              flatten(4, stringToOid('row3'),
-                                      4, 120, 1, 2, 3,
-                                      stringToOid('gamma7'),
-                                      stringToOid('end of row3')),
-                              v2c.OctetString(b"row3")),
-            # SNIMPY-MIB::snimpyIndexInt
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 6),
-                              flatten(4, stringToOid('row1'),
-                                      3, 1, 2, 3,
-                                      stringToOid('alpha5'),
-                                      stringToOid('end of row1')),
-                              v2c.Integer(4571)),
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 6),
-                              flatten(4, stringToOid('row2'),
-                                      4, 1, 0, 2, 3,
-                                      stringToOid('beta32'),
-                                      stringToOid('end of row2')),
-                              v2c.Integer(78741)),
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 6),
-                              flatten(4, stringToOid('row3'),
-                                      4, 120, 1, 2, 3,
-                                      stringToOid('gamma7'),
-                                      stringToOid('end of row3')),
-                              v2c.Integer(4110)),
-
-            # SNIMPY-MIB::snimpyInvalidTable
-            MibTable((1, 3, 6, 1, 2, 1, 45121, 2, 5)),
-            MibTableRow(
-                (1, 3, 6, 1, 2, 1, 45121, 2, 5, 1)).setIndexNames(
-                (0, "__MY_SNIMPY-MIB", "snimpyInvalidIndex")),
-            # SNIMPY-MIB::snimpyInvalidDescr
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 5, 1, 2),
-                              (1,),
-                              v2c.OctetString(b"Hello")),
-            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 5, 1, 2),
-                              (2,),
-                              v2c.OctetString(b"\xf1\x12\x13\x14\x15\x16")))
-
-        if self.emptyTable:
-            args += (
-                # SNIMPY-MIB::snimpyEmptyTable
-                MibTable((1, 3, 6, 1, 2, 1, 45121, 2, 6)),
+                # SNIMPY-MIB::snimpyIndexTable
+                MibTable((1, 3, 6, 1, 2, 1, 45121, 2, 3)),
                 MibTableRow(
-                    (1, 3, 6, 1, 2, 1, 45121, 2, 6, 1)).setIndexNames(
-                        (0, "__MY_SNIMPY-MIB", "snimpyEmptyIndex")))
+                    (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1)).setIndexNames(
+                    (0, mymib, m+"IndexVarLen"),
+                    (0, mymib, m+"IndexOidVarLen"),
+                    (0, mymib, m+"IndexFixedLen"),
+                    (1, mymib, m+"IndexImplied")),
+                # SNIMPY-MIB::snimpyIndexVarLen
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 1),
+                                  flatten(4, stringToOid('row1'),
+                                          3, 1, 2, 3,
+                                          stringToOid('alpha5'),
+                                          stringToOid('end of row1')),
+                                  v2c.OctetString(b"row1")),
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 1),
+                                  flatten(4, stringToOid('row2'),
+                                          4, 1, 0, 2, 3,
+                                          stringToOid('beta32'),
+                                          stringToOid('end of row2')),
+                                  v2c.OctetString(b"row2")),
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 1),
+                                  flatten(4, stringToOid('row3'),
+                                          4, 120, 1, 2, 3,
+                                          stringToOid('gamma7'),
+                                          stringToOid('end of row3')),
+                                  v2c.OctetString(b"row3")),
+                # SNIMPY-MIB::snimpyIndexInt
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 6),
+                                  flatten(4, stringToOid('row1'),
+                                          3, 1, 2, 3,
+                                          stringToOid('alpha5'),
+                                          stringToOid('end of row1')),
+                                  v2c.Integer(4571)),
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 6),
+                                  flatten(4, stringToOid('row2'),
+                                          4, 1, 0, 2, 3,
+                                          stringToOid('beta32'),
+                                          stringToOid('end of row2')),
+                                  v2c.Integer(78741)),
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 6),
+                                  flatten(4, stringToOid('row3'),
+                                          4, 120, 1, 2, 3,
+                                          stringToOid('gamma7'),
+                                          stringToOid('end of row3')),
+                                  v2c.Integer(4110)),
 
-        kwargs = dict(
-            # Indexes
-            snimpyIndexVarLen=MibTableColumn(
-                (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 1),
-                v2c.OctetString(
-                )),
-            snimpyIndexIntIndex=MibTableColumn(
-                (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 2),
-                v2c.Integer(
-                )).setMaxAccess(
-                "noaccess"),
-            snimpyIndexOidVarLen=MibTableColumn(
-                (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 3),
-                v2c.ObjectIdentifier(
-                )).setMaxAccess(
-                "noaccess"),
-            snimpyIndexFixedLen=MibTableColumn(
-                (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 4),
-                v2c.OctetString(
-                ).setFixedLength(
-                    6)).setMaxAccess(
-                "noaccess"),
-            snimpyIndexImplied=MibTableColumn(
-                (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 5),
-                v2c.OctetString(
-                )).setMaxAccess("noaccess"),
-            snimpyIndexInt=MibTableColumn(
-                (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 6),
-                v2c.Integer()).setMaxAccess("readwrite"),
-            snimpyInvalidIndex=MibTableColumn(
-                (1, 3, 6, 1, 2, 1, 45121, 2, 5, 1, 1),
-                v2c.Integer()).setMaxAccess("noaccess"),
-            snimpyInvalidDescr=MibTableColumn(
-                (1, 3, 6, 1, 2, 1, 45121, 2, 5, 1, 2),
-                v2c.OctetString()).setMaxAccess("readwrite")
-        )
+                # SNIMPY-MIB::snimpyInvalidTable
+                MibTable((1, 3, 6, 1, 2, 1, 45121, 2, 5)),
+                MibTableRow(
+                    (1, 3, 6, 1, 2, 1, 45121, 2, 5, 1)).setIndexNames(
+                    (0, mymib, m+"InvalidIndex")),
+                # SNIMPY-MIB::snimpyInvalidDescr
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 5, 1, 2),
+                                  (1,),
+                                  v2c.OctetString(b"Hello")),
+                MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 5, 1, 2),
+                                  (2,),
+                                  v2c.OctetString(
+                                    b"\xf1\x12\x13\x14\x15\x16")))
 
-        if self.emptyTable:
-            kwargs.update(dict(
-                snimpyEmptyIndex=MibTableColumn(
-                    (1, 3, 6, 1, 2, 1, 45121, 2, 6, 1, 1),
+            if self.emptyTable:
+                args += (
+                    # SNIMPY-MIB::snimpyEmptyTable
+                    MibTable((1, 3, 6, 1, 2, 1, 45121, 2, 6)),
+                    MibTableRow(
+                        (1, 3, 6, 1, 2, 1, 45121, 2, 6, 1)).setIndexNames(
+                            (0, mymib, m+"EmptyIndex")))
+
+            kwargs = dict(
+                # Indexes
+                snimpyIndexVarLen=MibTableColumn(
+                    (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 1),
+                    v2c.OctetString(
+                    )),
+                snimpyIndexIntIndex=MibTableColumn(
+                    (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 2),
+                    v2c.Integer(
+                    )).setMaxAccess(
+                    "noaccess"),
+                snimpyIndexOidVarLen=MibTableColumn(
+                    (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 3),
+                    v2c.ObjectIdentifier(
+                    )).setMaxAccess(
+                    "noaccess"),
+                snimpyIndexFixedLen=MibTableColumn(
+                    (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 4),
+                    v2c.OctetString(
+                    ).setFixedLength(
+                        6)).setMaxAccess(
+                    "noaccess"),
+                snimpyIndexImplied=MibTableColumn(
+                    (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 5),
+                    v2c.OctetString(
+                    )).setMaxAccess("noaccess"),
+                snimpyIndexInt=MibTableColumn(
+                    (1, 3, 6, 1, 2, 1, 45121, 2, 3, 1, 6),
+                    v2c.Integer()).setMaxAccess("readwrite"),
+                snimpyInvalidIndex=MibTableColumn(
+                    (1, 3, 6, 1, 2, 1, 45121, 2, 5, 1, 1),
                     v2c.Integer()).setMaxAccess("noaccess"),
-                snimpyEmptyDescr=MibTableColumn(
-                    (1, 3, 6, 1, 2, 1, 45121, 2, 6, 1, 2),
-                    v2c.OctetString()).setMaxAccess("readwrite")))
+                snimpyInvalidDescr=MibTableColumn(
+                    (1, 3, 6, 1, 2, 1, 45121, 2, 5, 1, 2),
+                    v2c.OctetString()).setMaxAccess("readwrite")
+            )
 
-        mibBuilder.exportSymbols(*args, **kwargs)
+            if self.emptyTable:
+                kwargs.update(dict(
+                    snimpyEmptyIndex=MibTableColumn(
+                        (1, 3, 6, 1, 2, 1, 45121, 2, 6, 1, 1),
+                        v2c.Integer()).setMaxAccess("noaccess"),
+                    snimpyEmptyDescr=MibTableColumn(
+                        (1, 3, 6, 1, 2, 1, 45121, 2, 6, 1, 2),
+                        v2c.OctetString()).setMaxAccess("readwrite")))
+
+            mibBuilder.exportSymbols(*args, **kwargs)
 
         # Start agent
         cmdrsp.GetCommandResponder(snmpEngine, snmpContext)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,6 +3,7 @@ import os
 import time
 from datetime import timedelta
 from snimpy.manager import load, Manager, snmp
+from snimpy.mib import MibLoader
 import agent
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -238,6 +239,21 @@ class TestManagerGet(TestManager):
         initial = self.manager.ifInOctets[2]
         current = self.manager.ifInOctets[2]
         self.assertGreater(current, initial)
+
+    def testMibLoaderGet(self):
+        """Create another manager with a different MibLoader"""
+        mibloader = MibLoader()
+        load('IF-MIB', mibloader)
+        load('SNMPv2-MIB', mibloader)
+        load(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "SNIMPY2-MIB.mib"), mibloader)
+
+        manager = Manager(host="127.0.0.1:{0}".format(self.agent.port),
+                               community="public",
+                               version=2, mibloader=mibloader)
+        self.assertEqual(manager.snimpy2IpAddress, "65.65.65.65")
+        self.assertRaises(AttributeError,
+                          getattr, manager, "snimpyIpAddress")
 
 
 class TestManagerRestrictModule(TestManager):

--- a/tests/test_mib.py
+++ b/tests/test_mib.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import sys
 from snimpy import mib, basictypes
+from snimpy.mib import MibLoader
 
 PYTHON3 = sys.version_info >= (3, 0)
 if PYTHON3:
@@ -10,9 +11,14 @@ if PYTHON3:
 
 class TestMibSnimpy(unittest.TestCase):
 
+    def mibLoader(self):
+        return mib
+
     def setUp(self):
-        mib.load(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                              "SNIMPY-MIB.mib"))
+        self.mib = self.mibLoader()
+        self.mib.load(os.path.join(
+                            os.path.dirname(os.path.abspath(__file__)),
+                            "SNIMPY-MIB.mib"))
         self.nodes = ["snimpy",
                       "snimpyScalars",
                       "snimpyTables"]
@@ -75,7 +81,7 @@ class TestMibSnimpy(unittest.TestCase):
 
     def testGetNodes(self):
         """Test that we can get all nodes"""
-        nodes = mib.getNodes('SNIMPY-MIB')
+        nodes = self.mib.getNodes('SNIMPY-MIB')
         snodes = sorted([str(a) for a in nodes])
         self.assertEqual(self.nodes,
                          snodes)
@@ -84,7 +90,7 @@ class TestMibSnimpy(unittest.TestCase):
 
     def testGetTables(self):
         """Test that we can get all tables"""
-        tables = mib.getTables('SNIMPY-MIB')
+        tables = self.mib.getTables('SNIMPY-MIB')
         stables = sorted([str(a) for a in tables])
         self.assertEqual(self.tables,
                          stables)
@@ -93,7 +99,7 @@ class TestMibSnimpy(unittest.TestCase):
 
     def testGetColumns(self):
         """Test that we can get all columns"""
-        columns = mib.getColumns('SNIMPY-MIB')
+        columns = self.mib.getColumns('SNIMPY-MIB')
         scolumns = sorted([str(a) for a in columns])
         self.assertEqual(self.columns,
                          scolumns)
@@ -102,7 +108,7 @@ class TestMibSnimpy(unittest.TestCase):
 
     def testGetScalars(self):
         """Test that we can get all scalars"""
-        scalars = mib.getScalars('SNIMPY-MIB')
+        scalars = self.mib.getScalars('SNIMPY-MIB')
         sscalars = sorted([str(a) for a in scalars])
         self.assertEqual(self.scalars, sscalars)
         for n in scalars:
@@ -111,54 +117,60 @@ class TestMibSnimpy(unittest.TestCase):
     def testGet(self):
         """Test that we can get all named attributes"""
         for i in self.scalars:
-            self.assertEqual(str(mib.get('SNIMPY-MIB', i)), i)
-            self.assert_(isinstance(mib.get('SNIMPY-MIB', i), mib.Scalar))
+            self.assertEqual(str(self.mib.get('SNIMPY-MIB', i)), i)
+            self.assert_(isinstance(self.mib.get('SNIMPY-MIB', i), mib.Scalar))
         for i in self.tables:
-            self.assertEqual(str(mib.get('SNIMPY-MIB', i)), i)
-            self.assert_(isinstance(mib.get('SNIMPY-MIB', i), mib.Table))
+            self.assertEqual(str(self.mib.get('SNIMPY-MIB', i)), i)
+            self.assert_(isinstance(self.mib.get('SNIMPY-MIB', i), mib.Table))
         for i in self.columns:
-            self.assertEqual(str(mib.get('SNIMPY-MIB', i)), i)
-            self.assert_(isinstance(mib.get('SNIMPY-MIB', i), mib.Column))
+            self.assertEqual(str(self.mib.get('SNIMPY-MIB', i)), i)
+            self.assert_(isinstance(self.mib.get('SNIMPY-MIB', i), mib.Column))
         for i in self.nodes:
-            self.assertEqual(str(mib.get('SNIMPY-MIB', i)), i)
-            self.assert_(isinstance(mib.get('SNIMPY-MIB', i), mib.Node))
+            self.assertEqual(str(self.mib.get('SNIMPY-MIB', i)), i)
+            self.assert_(isinstance(self.mib.get('SNIMPY-MIB', i), mib.Node))
 
     def testGetByOid(self):
         """Test that we can get all named attributes by OID."""
         for i in self.scalars:
-            nodebyname = mib.get('SNIMPY-MIB', i)
-            self.assertEqual(str(mib.getByOid(nodebyname.oid)), i)
-            self.assert_(isinstance(mib.getByOid(nodebyname.oid), mib.Scalar))
+            nodebyname = self.mib.get('SNIMPY-MIB', i)
+            self.assertEqual(str(self.mib.getByOid(nodebyname.oid)), i)
+            self.assert_(isinstance(self.mib.getByOid(nodebyname.oid),
+                                    mib.Scalar))
         for i in self.tables:
-            nodebyname = mib.get('SNIMPY-MIB', i)
-            self.assertEqual(str(mib.getByOid(nodebyname.oid)), i)
-            self.assert_(isinstance(mib.getByOid(nodebyname.oid), mib.Table))
+            nodebyname = self.mib.get('SNIMPY-MIB', i)
+            self.assertEqual(str(self.mib.getByOid(nodebyname.oid)), i)
+            self.assert_(isinstance(self.mib.getByOid(nodebyname.oid),
+                                    mib.Table))
         for i in self.columns:
-            nodebyname = mib.get('SNIMPY-MIB', i)
-            self.assertEqual(str(mib.getByOid(nodebyname.oid)), i)
-            self.assert_(isinstance(mib.getByOid(nodebyname.oid), mib.Column))
+            nodebyname = self.mib.get('SNIMPY-MIB', i)
+            self.assertEqual(str(self.mib.getByOid(nodebyname.oid)), i)
+            self.assert_(isinstance(self.mib.getByOid(nodebyname.oid),
+                                    mib.Column))
         for i in self.nodes:
-            nodebyname = mib.get('SNIMPY-MIB', i)
-            self.assertEqual(str(mib.getByOid(nodebyname.oid)), i)
-            self.assert_(isinstance(mib.getByOid(nodebyname.oid), mib.Node))
+            nodebyname = self.mib.get('SNIMPY-MIB', i)
+            self.assertEqual(str(self.mib.getByOid(nodebyname.oid)), i)
+            self.assert_(isinstance(self.mib.getByOid(nodebyname.oid),
+                                    mib.Node))
 
     def testGetByOid_UnknownOid(self):
         """Test that unknown OIDs raise an exception."""
-        self.assertRaises(mib.SMIException, mib.getByOid, (255,))
+        self.assertRaises(mib.SMIException, self.mib.getByOid, (255,))
 
     def testGetType(self):
         """Test that _getType properly identifies known and unknown types."""
         self.assertEqual(b"PhysAddress",
-                         mib.ffi.string(mib._getType("PhysAddress").name))
+                         mib.ffi.string(
+                            self.mib._getType("PhysAddress").name))
         self.assertEqual(b"InetAddress",
-                         mib.ffi.string(mib._getType(b"InetAddress").name))
-        self.assertEqual(None, mib._getType("SomeUnknownType.kjgf"))
-        self.assertEqual(None, mib._getType("snimpySimpleTable"))
+                         mib.ffi.string(
+                            self.mib._getType(b"InetAddress").name))
+        self.assertEqual(None, self.mib._getType("SomeUnknownType.kjgf"))
+        self.assertEqual(None, self.mib._getType("snimpySimpleTable"))
 
     def testTableColumnRelation(self):
         """Test that we can get the column from the table and vice-versa"""
         for i in self.tables:
-            table = mib.get('SNIMPY-MIB', i)
+            table = self.mib.get('SNIMPY-MIB', i)
             for r in table.columns:
                 self.assert_(isinstance(r, mib.Column))
                 self.assertEqual(str(r.table), str(i))
@@ -171,7 +183,7 @@ class TestMibSnimpy(unittest.TestCase):
             tcolumns.sort()
             self.assertEqual(columns, tcolumns)
         for r in self.columns:
-            column = mib.get('SNIMPY-MIB', r)
+            column = self.mib.get('SNIMPY-MIB', r)
             table = column.table
             self.assert_(isinstance(table, mib.Table))
             prefix = str(table).replace("Table", "")
@@ -198,11 +210,11 @@ class TestMibSnimpy(unittest.TestCase):
               "snimpyComplexSecondIP": basictypes.IpAddress,
               "snimpyComplexState": basictypes.Enum}
         for t in tt:
-            self.assertEqual(mib.get('SNIMPY-MIB', t).type, tt[t])
+            self.assertEqual(self.mib.get('SNIMPY-MIB', t).type, tt[t])
 
         # Also check we get an exception when no type available
         def call():
-            mib.get('SNIMPY-MIB', 'snimpySimpleTable').type
+            self.mib.get('SNIMPY-MIB', 'snimpySimpleTable').type
         self.assertRaises(mib.SMIException, call)
 
     def testRanges(self):
@@ -224,16 +236,18 @@ class TestMibSnimpy(unittest.TestCase):
               "snimpyComplexState": None
               }
         for t in tt:
-            self.assertEqual(mib.get('SNIMPY-MIB', t).ranges, tt[t])
+            self.assertEqual(self.mib.get('SNIMPY-MIB', t).ranges,
+                             tt[t])
 
     def testEnums(self):
         """Test that we got the enum values correctly"""
-        self.assertEqual(mib.get('SNIMPY-MIB', "snimpyInteger").enum, None)
-        self.assertEqual(mib.get("SNIMPY-MIB", "snimpyEnum").enum,
+        self.assertEqual(self.mib.get('SNIMPY-MIB',
+                                      "snimpyInteger").enum, None)
+        self.assertEqual(self.mib.get("SNIMPY-MIB", "snimpyEnum").enum,
                          {1: "up",
                           2: "down",
                           3: "testing"})
-        self.assertEqual(mib.get("SNIMPY-MIB", "snimpyBits").enum,
+        self.assertEqual(self.mib.get("SNIMPY-MIB", "snimpyBits").enum,
                          {0: "first",
                           1: "second",
                           2: "third",
@@ -242,30 +256,33 @@ class TestMibSnimpy(unittest.TestCase):
     def testIndexes(self):
         """Test that we can retrieve correctly the index of tables"""
         self.assertEqual(
-            [str(i) for i in mib.get("SNIMPY-MIB", "snimpySimpleTable").index],
+            [str(i) for i in self.mib.get("SNIMPY-MIB",
+                                          "snimpySimpleTable").index],
             ["snimpySimpleIndex"])
         self.assertEqual(
             [str(i)
-             for i in mib.get("SNIMPY-MIB", "snimpyComplexTable").index],
+             for i in self.mib.get("SNIMPY-MIB",
+                                   "snimpyComplexTable").index],
             ["snimpyComplexFirstIP", "snimpyComplexSecondIP"])
         self.assertEqual(
             [str(i)
-             for i in mib.get("SNIMPY-MIB", "snimpyInetAddressTable").index],
+             for i in self.mib.get("SNIMPY-MIB",
+                                   "snimpyInetAddressTable").index],
             ["snimpyInetAddressType", "snimpyInetAddress"])
 
     def testImplied(self):
         """Check that we can get implied attribute for a given table"""
         self.assertEqual(
-            mib.get("SNIMPY-MIB",
-                    'snimpySimpleTable').implied,
+            self.mib.get("SNIMPY-MIB",
+                         'snimpySimpleTable').implied,
             False)
         self.assertEqual(
-            mib.get("SNIMPY-MIB",
-                    'snimpyComplexTable').implied,
+            self.mib.get("SNIMPY-MIB",
+                         'snimpyComplexTable').implied,
             False)
         self.assertEqual(
-            mib.get("SNIMPY-MIB",
-                    'snimpyIndexTable').implied,
+            self.mib.get("SNIMPY-MIB",
+                         'snimpyIndexTable').implied,
             True)
 
     def testOid(self):
@@ -282,41 +299,51 @@ class TestMibSnimpy(unittest.TestCase):
                 "snimpyComplexState": (1, 3, 6, 1, 2, 1, 45121, 2, 2, 1, 3),
                 }
         for o in oids:
-            self.assertEqual(mib.get('SNIMPY-MIB', o).oid, oids[o])
+            self.assertEqual(self.mib.get('SNIMPY-MIB', o).oid, oids[o])
 
     def testLoadedMibNames(self):
         """Check that only expected modules were loaded."""
         for module in self.expected_modules:
-            self.assertTrue(module in list(mib.loadedMibNames()))
+            self.assertTrue(module in list(self.mib.loadedMibNames()))
 
     def testLoadInexistantModule(self):
         """Check that we get an exception when loading an inexistant module"""
-        self.assertRaises(mib.SMIException, mib.load, "idontexist.gfdgfdg")
+        self.assertRaises(mib.SMIException, self.mib.load,
+                          "idontexist.gfdgfdg")
 
     def testLoadInvalidModule(self):
         """Check that an obviously invalid module cannot be loaded"""
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             "SNIMPY-INVALID-MIB.mib")
-        self.assertRaises(mib.SMIException, mib.load, path)
-        self.assertRaises(mib.SMIException, mib.getNodes, "SNIMPY-INVALID-MIB")
-        self.assertRaises(mib.SMIException, mib.get,
+        self.assertRaises(mib.SMIException, self.mib.load, path)
+        self.assertRaises(mib.SMIException, self.mib.getNodes,
+                          "SNIMPY-INVALID-MIB")
+        self.assertRaises(mib.SMIException, self.mib.get,
                           "SNIMPY-INVALID-MIB", "invalidSnimpyNode")
 
     def testAccesInexistantModule(self):
         """Check that we get an exception when querying inexistant module"""
-        self.assertRaises(mib.SMIException, mib.getNodes, "idontexist.kjgf")
-        self.assertRaises(mib.SMIException, mib.getScalars, "idontexist.kjgf")
-        self.assertRaises(mib.SMIException, mib.getTables, "idontexist.kjgf")
-        self.assertRaises(mib.SMIException, mib.getColumns, "idontexist.kjgf")
+        self.assertRaises(mib.SMIException, self.mib.getNodes,
+                          "idontexist.kjgf")
+        self.assertRaises(mib.SMIException, self.mib.getScalars,
+                          "idontexist.kjgf")
+        self.assertRaises(mib.SMIException, self.mib.getTables,
+                          "idontexist.kjgf")
+        self.assertRaises(mib.SMIException, self.mib.getColumns,
+                          "idontexist.kjgf")
 
     def testFmt(self):
         """Check that we get FMT from types"""
-        self.assertEqual(mib.get("SNIMPY-MIB", 'snimpySimplePhys').fmt, "1x:")
-        self.assertEqual(mib.get("SNIMPY-MIB", 'snimpyInteger').fmt, "d-2")
+        self.assertEqual(
+                self.mib.get("SNIMPY-MIB", 'snimpySimplePhys').fmt,
+                "1x:")
+        self.assertEqual(
+                self.mib.get("SNIMPY-MIB", 'snimpyInteger').fmt,
+                "d-2")
 
     def testTypeOverrides(self):
         """Check that we can override a type"""
-        table = mib.get("SNIMPY-MIB", "snimpyInetAddressTable")
+        table = self.mib.get("SNIMPY-MIB", "snimpyInetAddressTable")
         addrtype_attr = table.index[0]
         addr_attr = table.index[1]
 
@@ -369,7 +396,7 @@ class TestMibSnimpy(unittest.TestCase):
         self.assertEqual(bytes(addr), b"\x7f\0\0\1")
 
     def testTypeOverrides_Errors(self):
-        table = mib.get("SNIMPY-MIB", "snimpyInetAddressTable")
+        table = self.mib.get("SNIMPY-MIB", "snimpyInetAddressTable")
         attr = table.index[1]
 
         # Value with the wrong type.
@@ -389,7 +416,7 @@ class TestMibSnimpy(unittest.TestCase):
 
     def testTypeName(self):
         """Check that we can get the current declared type name"""
-        table = mib.get("SNIMPY-MIB", "snimpyInetAddressTable")
+        table = self.mib.get("SNIMPY-MIB", "snimpyInetAddressTable")
         attr = table.index[1]
 
         self.assertEqual(attr.typeName, b"InetAddress")
@@ -400,8 +427,29 @@ class TestMibSnimpy(unittest.TestCase):
         attr.typeName = b"InetAddressIPv6"
         self.assertEqual(attr.typeName, b"InetAddressIPv6")
 
-        attr = mib.get("SNIMPY-MIB", "snimpySimpleIndex")
+        attr = self.mib.get("SNIMPY-MIB", "snimpySimpleIndex")
         self.assertEqual(attr.typeName, b"Integer32")
+
+    def testMibLoader(self):
+        """Check that you can create an isolated MibLoader"""
+        mloader = MibLoader()
+        mloader.load(os.path.join(
+                            os.path.dirname(os.path.abspath(__file__)),
+                            "SNIMPY2-MIB.mib"))
+        mloader.get("SNIMPY2-MIB", "snimpy2InetAddressTable")
+        mloader.get("SNIMPY2-MIB", "snimpy2IpAddress")
+        self.mib.get("SNIMPY-MIB", "snimpyInetAddressTable")
+        with self.assertRaises(mib.SMIException):
+            mloader.get("SNIMPY-MIB", "snimpyInetAddressTable")
+        with self.assertRaises(mib.SMIException):
+            self.mib.get("SNIMPY2-MIB", "snimpy2InetAddressTable")
+
+
+class TestMibLoaderSnimpy(TestMibSnimpy):
+    """Tests with a different MIB loader"""
+
+    def mibLoader(self):
+        return MibLoader()
 
 
 class TestSmi(unittest.TestCase):


### PR DESCRIPTION
I have added a MibLoader class in the mib module so you can load and use isolated sets of MIBs. It uses the dataset feature of libsmi (smiInit("tag:dataset")). I have added some simple tests for it, and all the existing tests are passing (on my machine at least).
One issue is that AFAIK there is not way to release the memory of only that dataset, so if you want to start from scratch you need to reset libsmi completely.
The goal is to support multiple agents with different versions of the same MIB.

Let me know if there are other things I need to do.