### PR TITLE
IMPLIED index for tables whose index re-uses objects from other tables' indexes

### DIFF
--- a/snimpy/basictypes.py
+++ b/snimpy/basictypes.py
@@ -134,7 +134,7 @@ class Type(object):
         """Prepare the instance to be sent on the wire."""
         raise NotImplementedError  # pragma: no cover
 
-    def toOid(self):
+    def toOid(self, implied=False):
         """Convert to an OID.
 
         If this function is implemented, then class function
@@ -149,7 +149,7 @@ class Type(object):
         raise NotImplementedError  # pragma: no cover
 
     @classmethod
-    def fromOid(cls, entity, oid):
+    def fromOid(cls, entity, oid, implied=False):
         """Create instance from an OID.
 
         This is the sister function of :meth:`toOid`.
@@ -230,11 +230,11 @@ class IpAddress(Type):
                 str(".".join(["{0:d}".format(x) for x in self._value])))
         )
 
-    def toOid(self):
+    def toOid(self, implied=False):
         return tuple(self._value)
 
     @classmethod
-    def fromOid(cls, entity, oid):
+    def fromOid(cls, entity, oid, implied=False):
         if len(oid) < 4:
             raise ValueError(
                 "{0!r} is too short for an IP address".format(oid))
@@ -261,7 +261,7 @@ class IpAddress(Type):
 
 class StringOrOctetString(Type):
 
-    def toOid(self):
+    def toOid(self, implied=False):
         # To convert properly to OID, we need to know if it is a
         # fixed-len string, an implied string or a variable-len
         # string.
@@ -274,7 +274,7 @@ class StringOrOctetString(Type):
         raise NotImplementedError
 
     @classmethod
-    def fromOid(cls, entity, oid):
+    def fromOid(cls, entity, oid, implied=False):
         type = cls._fixedOrImplied(entity)
         if type == "implied":
             # Eat everything
@@ -570,11 +570,11 @@ class Integer(Type, long):
             return rfc1902.Integer(self._value)
         raise OverflowError("too small to be packed")
 
-    def toOid(self):
+    def toOid(self, implied=False):
         return (self._value,)
 
     @classmethod
-    def fromOid(cls, entity, oid):
+    def fromOid(cls, entity, oid, implied=False):
         if len(oid) < 1:
             raise ValueError("{0} is too short for an integer".format(oid))
         return (1, cls(entity, oid[0]))
@@ -653,7 +653,7 @@ class Enum(Integer):
         return rfc1902.Integer(self._value)
 
     @classmethod
-    def fromOid(cls, entity, oid):
+    def fromOid(cls, entity, oid, implied=False):
         if len(oid) < 1:
             raise ValueError(
                 "{0!r} is too short for an enumeration".format(oid))
@@ -699,13 +699,13 @@ class Oid(Type):
     def pack(self):
         return rfc1902.univ.ObjectIdentifier(self._value)
 
-    def toOid(self):
+    def toOid(self, implied=False):
         if self._fixedOrImplied(self.entity):
             return self._value
         return tuple([len(self._value)] + list(self._value))
 
     @classmethod
-    def fromOid(cls, entity, oid):
+    def fromOid(cls, entity, oid, implied=False):
         if cls._fixedOrImplied(entity) == "fixed":
             # A fixed OID? We don't like this. Provide a real example.
             raise ValueError(
@@ -794,11 +794,11 @@ class Timeticks(Type):
             self._value.seconds * 100 + \
             self._value.microseconds // 10000
 
-    def toOid(self):
+    def toOid(self, implied=False):
         return (int(self),)
 
     @classmethod
-    def fromOid(cls, entity, oid):
+    def fromOid(cls, entity, oid, implied=False):
         if len(oid) < 1:
             raise ValueError("{0!r} is too short for a timetick".format(oid))
         return (1, cls(entity, oid[0]))

--- a/snimpy/manager.py
+++ b/snimpy/manager.py
@@ -513,7 +513,7 @@ class ProxyTable(ProxyIter):
     """
 
     def __init__(self, session, table, loose):
-        self.proxy = table.index[0]
+        self.proxy = table.columns[0]
         self.session = session
         self._loose = loose
 

--- a/snimpy/manager.py
+++ b/snimpy/manager.py
@@ -441,7 +441,7 @@ class ProxyIter(Proxy, Sized, Iterable, Container):
             # Convert filter elements to correct types
             for i, part in enumerate(table_filter):
                 part = indexes[i].type(indexes[i], part, raw=False)
-                # implied = False: 
+                # implied = False:
                 #   index never includes last element
                 #   (see 'len(table_filter) >= len(indexes)')
                 oid_suffix.extend(part.toOid(implied=False))
@@ -462,7 +462,7 @@ class ProxyIter(Proxy, Sized, Iterable, Container):
             # oid should be turned into index
             index = tuple(oid[len(self.proxy.oid):])
             target = []
-            for i,x in enumerate(indexes):
+            for i, x in enumerate(indexes):
                 implied = self.proxy.table.implied and i == len(indexes)-1
                 l, o = x.type.fromOid(x, index, implied)
                 target.append(x.type(x, o))

--- a/tests/SNIMPY-MIB.mib
+++ b/tests/SNIMPY-MIB.mib
@@ -508,6 +508,41 @@ snimpyEmptyDescr OBJECT-TYPE
             "Blah blah"
     ::= { snimpyEmptyEntry 2 }
 
+-- A table whose index re-uses objects from other tables' indexes
+
+snimpyReuseIndexTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF SnimpyReuseIndexEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "A table whose index re-uses objects from
+             other tables' indexes"
+    ::= { snimpyTables 7 }
+
+snimpyReuseIndexEntry OBJECT-TYPE
+    SYNTAX      SnimpyReuseIndexEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+            "Entry for our snimpyReuseIndexTable table
+             note that snimpyIndexImplied is not the last item
+             so it cannot be implied"
+    INDEX   { snimpyIndexImplied, snimpySimpleIndex }
+    ::= { snimpyReuseIndexTable 1 }
+
+SnimpyReuseIndexEntry ::=
+    SEQUENCE {
+        snimpyReuseIndexValue       INTEGER
+    }
+
+snimpyReuseIndexValue OBJECT-TYPE
+    SYNTAX      INTEGER
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+            "Integer value"
+    ::= { snimpyReuseIndexEntry 1 }
+
 -- A notification
 
 snimpyNotification NOTIFICATION-TYPE
@@ -520,6 +555,5 @@ snimpyNotification NOTIFICATION-TYPE
     DESCRIPTION
             "A notification"
     ::= { snimpyTraps 1 }
-
 
 END

--- a/tests/agent.py
+++ b/tests/agent.py
@@ -298,6 +298,22 @@ class TestAgent(object):
                                       stringToOid('end of row3')),
                               v2c.Integer(4110)),
 
+            # SNIMPY-MIB::snimpyReuseIndexTable
+            MibTable((1, 3, 6, 1, 2, 1, 45121, 2, 7)),
+            MibTableRow(
+                (1, 3, 6, 1, 2, 1, 45121, 2, 7, 1)).setIndexNames(
+                (0, "__MY_SNIMPY-MIB", "snimpyIndexImplied"),
+                (0, "__MY_SNIMPY-MIB", "snimpySimpleIndex")),
+            # SNIMPY-MIB::snimpyReuseIndexValue
+            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 7, 1, 1),
+                              flatten(11, stringToOid('end of row1'),
+                                      4),
+                              v2c.Integer(1785)),
+            MibScalarInstance((1, 3, 6, 1, 2, 1, 45121, 2, 7, 1, 1),
+                              flatten(11, stringToOid('end of row1'),
+                                      5),
+                              v2c.Integer(2458)),
+
             # SNIMPY-MIB::snimpyInvalidTable
             MibTable((1, 3, 6, 1, 2, 1, 45121, 2, 5)),
             MibTableRow(
@@ -353,7 +369,10 @@ class TestAgent(object):
                 v2c.Integer()).setMaxAccess("noaccess"),
             snimpyInvalidDescr=MibTableColumn(
                 (1, 3, 6, 1, 2, 1, 45121, 2, 5, 1, 2),
-                v2c.OctetString()).setMaxAccess("readwrite")
+                v2c.OctetString()).setMaxAccess("readwrite"),
+            snimpyReuseIndexValue=MibTableColumn(
+                (1, 3, 6, 1, 2, 1, 45121, 2, 7, 1, 1),
+                v2c.Integer()).setMaxAccess("readwrite")
         )
 
         if self.emptyTable:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -154,6 +154,22 @@ class TestManagerGet(TestManager):
                           (("row3", (120, 1, 2, 3),
                             "gamma7", "end of row3"), 4110)])
 
+    def testWalkReuseIndexes(self):
+        """Test if we can walk a table with re-used indexes"""
+        results = [(idx, self.manager.snimpyReuseIndexValue[idx])
+                   for idx in self.manager.snimpyReuseIndexValue]
+        self.assertEqual(results,
+                         [(("end of row1", 4), 1785),
+                          (("end of row1", 5), 2458)])
+
+    def testWalkTableWithReuseIndexes(self):
+        """Test if we can walk a table with re-used indexes"""
+        results = [(idx, self.manager.snimpyReuseIndexValue[idx])
+                   for idx in self.manager.snimpyReuseIndexTable]
+        self.assertEqual(results,
+                         [(("end of row1", 4), 1785),
+                          (("end of row1", 5), 2458)])
+
     def testWalkPartialIndexes(self):
         """Test if we can walk a slice of a table given a partial index"""
         results = [(idx, self.manager.ifRcvAddressType[idx])

--- a/tests/test_mib.py
+++ b/tests/test_mib.py
@@ -23,7 +23,8 @@ class TestMibSnimpy(unittest.TestCase):
                        "snimpySimpleTable",
                        "snimpyIndexTable",
                        "snimpyInvalidTable",
-                       "snimpyEmptyTable"]
+                       "snimpyEmptyTable",
+                       "snimpyReuseIndexTable"]
         self.tables.sort()
         self.columns = ["snimpyComplexFirstIP",
                         "snimpyComplexSecondIP",
@@ -44,7 +45,8 @@ class TestMibSnimpy(unittest.TestCase):
                         "snimpyInvalidIndex",
                         "snimpyInvalidDescr",
                         "snimpyEmptyIndex",
-                        "snimpyEmptyDescr"
+                        "snimpyEmptyDescr",
+                        "snimpyReuseIndexValue"
                         ]
         self.columns.sort()
         self.scalars = ["snimpyIpAddress",


### PR DESCRIPTION
When there is a MIB table who reuses index objects from another table, the index can be 'implied' in one table, but the same object can be not implied in the index of the other different table.

So when converting to/from OID, whether or not the length is present depends on the table for which it is used, it is not a property of the object itself.

See e.g. in the tests "snimpyReuseIndexTable" which is uses "snimpyIndexImplied" in the index, but is not "IMPLIED" in this table.