### PR TITLE
support Bits type spanning multiple bytes

### DIFF
--- a/snimpy/basictypes.py
+++ b/snimpy/basictypes.py
@@ -833,10 +833,11 @@ class Bits(Type):
                     continue
                 for j in range(8):
                     if ord2(x) & (1 << (7 - j)):
-                        if j not in entity.enum:
+                        k = (i * 8) + j
+                        if k not in entity.enum:
                             tryalternate = True
                             break
-                        bits.add(j)
+                        bits.add(k)
                 if tryalternate:
                     break
             if not tryalternate:
@@ -861,11 +862,12 @@ class Bits(Type):
         return bits
 
     def pack(self):
-        string = []
+        if self._value:
+            string = [0] * ((max(self._value) // 8) + 1)
+        else:
+            string = []
         for b in self._value:
-            if len(string) < (b >> 4) + 1:
-                string.extend([0] * ((b >> 4) - len(string) + 1))
-            string[b >> 416] |= 1 << (7 - b % 16)
+            string[b // 8] |= 1 << (7 - b % 8)
         return rfc1902.Bits(b"".join([chr2(x) for x in string]))
 
     def __eq__(self, other):

--- a/tests/SNIMPY-MIB.mib
+++ b/tests/SNIMPY-MIB.mib
@@ -133,7 +133,8 @@ snimpyBits	OBJECT-TYPE
                   first(0),
 		  second(1),
 		  third(2),
-		  last(7)
+		  last(7),
+		  secondByte(8)
 		}
     MAX-ACCESS  read-only
     STATUS	current

--- a/tests/agent.py
+++ b/tests/agent.py
@@ -239,7 +239,7 @@ class TestAgent(object):
                       v2c.OctetString()).setMaxAccess("readwrite"),
             MibScalarInstance(
                 (1, 3, 6, 1, 2, 1, 45121, 1, 11), (0,),
-                v2c.OctetString(b"\xa0")),
+                v2c.OctetString(b"\xa0\x80")),
             # SNIMPY-MIB::snimpyMacAddress
             MibScalar((1, 3, 6, 1, 2, 1, 45121, 1, 15),
                       v2c.OctetString()).setMaxAccess("readwrite"),

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -88,7 +88,7 @@ class TestManagerGet(TestManager):
 
     def testScalar_Bits(self):
         """Retrieve Bits as a scalar"""
-        self.scalarGetAndCheck("snimpyBits", ["first", "third"])
+        self.scalarGetAndCheck("snimpyBits", ["first", "third", "secondByte"])
 
     def testScalar_MacAddress(self):
         """Retrieve MacAddress as a scalar"""
@@ -334,7 +334,7 @@ class TestManagerSet(TestManager):
 
     def testScalar_Bits(self):
         """Retrieve Bits as a scalar"""
-        self.scalarSetAndCheck("snimpyBits", ["first", "second"])
+        self.scalarSetAndCheck("snimpyBits", ["first", "second", "secondByte"])
 
     def testScalar_MacAddress(self):
         """Retrieve MAC address as a scala"""

--- a/tests/test_mib.py
+++ b/tests/test_mib.py
@@ -259,7 +259,8 @@ class TestMibSnimpy(unittest.TestCase):
                          {0: "first",
                           1: "second",
                           2: "third",
-                          7: "last"})
+                          7: "last",
+                          8: "secondByte"})
 
     def testIndexes(self):
         """Test that we can retrieve correctly the index of tables"""


### PR DESCRIPTION
Currently, the encoding/decoding of the bits type is incorrect when multiple bytes are needed (i.e. values > 8). This code fixes that.