### PR TITLE
Fix iteration over table with non-accessible column

### DIFF
--- a/snimpy/manager.py
+++ b/snimpy/manager.py
@@ -508,12 +508,18 @@ class ProxyIter(Proxy, Sized, Iterable, Container):
 class ProxyTable(ProxyIter):
     """Proxy for table access.
 
-    We just use the first index as a column. However, the mapping
+    We just use the first accessible index as a column. However, the mapping
     operations are not available.
     """
 
     def __init__(self, session, table, loose):
-        self.proxy = table.columns[0]
+        self.proxy = None
+        for column in table.columns:
+            if column.accessible:
+                self.proxy = column
+                break
+        if self.proxy is None:
+            raise NotImplementedError("No accessible column in the table.")
         self.session = session
         self._loose = loose
 

--- a/snimpy/mib.py
+++ b/snimpy/mib.py
@@ -238,6 +238,11 @@ class Node(object):
             element = _smi.smiGetNextNamedNumber(element)
         return result
 
+    @property
+    def accessible(self):
+        return (self.node.access not in (_smi.SMI_ACCESS_NOT_IMPLEMENTED,
+                                         _smi.SMI_ACCESS_NOT_ACCESSIBLE))
+
     def __str__(self):
         return ffi.string(self.node.name).decode("ascii")
 

--- a/snimpy/smi_build.py
+++ b/snimpy/smi_build.py
@@ -59,6 +59,14 @@ typedef enum SmiIndexkind {
     ...
 } SmiIndexkind;
 
+typedef enum SmiAccess {
+    SMI_ACCESS_NOT_IMPLEMENTED,
+    SMI_ACCESS_NOT_ACCESSIBLE,
+    SMI_ACCESS_READ_ONLY,
+    SMI_ACCESS_READ_WRITE,
+    ...
+} SmiAccess;
+
 typedef unsigned int SmiNodekind;
 #define SMI_NODEKIND_NODE         ...
 #define SMI_NODEKIND_SCALAR       ...
@@ -75,6 +83,7 @@ typedef struct SmiNode {
     SmiIndexkind        indexkind;
     int                 implied;
     SmiNodekind         nodekind;
+    SmiAccess           access;
     ...;
 } SmiNode;
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -120,6 +120,10 @@ class TestManagerGet(TestManager):
                           (2, "eth0", 6),
                           (3, "eth1", 6)])
 
+    def testWalkNotAccessible(self):
+        """Test we can walk a table with the first entry not accessible."""
+        list(self.manager.ifRcvAddressTable)
+
     def testWalkIfDescrWithoutBulk(self):
         """Walk IF-MIB::ifDescr without GETBULK"""
         self.session.bulk = False


### PR DESCRIPTION
When the first column of a table is not-accessible, trying to iterate over it will fail because the ProxyTable uses the first column.
I fixed it by taking the first accessible column instead.