### PR TITLE
manager: add items() in addition to iteritems()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+0.8.14 (????-??-??)
++++++++++++++++++++
+
+ * Add ``items()`` in addition to ``iteritems()`` This is an iterator
+   on Python 3 and return a list of items in Python 2.
+
 0.8.13 (2018-10-12)
 +++++++++++++++++++
 

--- a/snimpy/manager.py
+++ b/snimpy/manager.py
@@ -28,6 +28,7 @@ Here is a simple example of use of this module::
     <String: lo>
 """
 
+import sys
 import inspect
 from time import time
 from collections import MutableMapping, Container, Iterable, Sized
@@ -429,6 +430,11 @@ class ProxyIter(Proxy, Sized, Iterable, Container):
     def __len__(self):
         len(list(self.iteritems()))
 
+    def items(self, *args, **kwargs):
+        if sys.version_info >= (3, 0):
+            return self.iteritems(*args, **kwargs)
+        return list(self.iteritems(*args, **kwargs))
+
     def iteritems(self, table_filter=None):
         count = 0
         oid = self.proxy.oid
@@ -567,6 +573,11 @@ class ProxyColumn(ProxyIter, MutableMapping):
         but with appended OID suffix"""
         new_suffix = self._oid_suffix + index
         return ProxyColumn(self.session, self.proxy, self._loose, new_suffix)
+
+    def items(self, *args, **kwargs):
+        if sys.version_info >= (3, 0):
+            return self.iteritems(*args, **kwargs)
+        return list(self.iteritems(*args, **kwargs))
 
     def iteritems(self, table_filter=None):
         resulting_filter = self._oid_suffix

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -188,6 +188,9 @@ class TestManagerGet(TestManager):
         results = list(self.manager.ifRcvAddressType.iteritems(3))
         self.assertEqual(results,
                          [((3, "6d:6e:6f:70:71:72"), 1)])
+        results = list(self.manager.ifRcvAddressType.items(3))
+        self.assertEqual(results,
+                         [((3, "6d:6e:6f:70:71:72"), 1)])
 
     def testWalkInvalidPartialIndexes(self):
         """Try to get a table slice with an incorrect index filter"""


### PR DESCRIPTION
With Python 3, this is just an alias. With Python 2, this returns a
copy.

Fix #88 