### PR TITLE
Issue#93 Support Community Strings greater than 32 characaters

### DIFF
--- a/snimpy/snmp.py
+++ b/snimpy/snmp.py
@@ -145,7 +145,7 @@ class Session(object):
         # Put authentication stuff in self._auth
         if version in [1, 2]:
             self._auth = cmdgen.CommunityData(
-                community, community, version - 1)
+                community[0:30], community, version - 1)
         elif version == 3:
             if secname is None:
                 secname = community


### PR DESCRIPTION
This allows the use of community strings greater than 32 characters in length. The CommunityData constructor is duplicating the string for both the CommunityIndex which is limited to 32 characters in length and the Community itself which likely has limitation of 255 characters. This will automatically slice the community index to less than 31 characters. Community index construction in CommunityData constructor will not be affected if less than 31 chars in length.

