### PR TITLE
Add support for SHA-2 authentication protocols

### DIFF
--- a/snimpy/snmp.py
+++ b/snimpy/snmp.py
@@ -106,8 +106,8 @@ class Session:
         :param secname: Security name to use for SNMPv3 only.
         :type secname: str
         :param authprotocol: Authorization protocol to use for
-            SNMPv3. This can be `None` or either the string `SHA` or
-            `MD5`.
+            SNMPv3. This can be `None` or one of the strings `SHA`,
+            `MD5`, `SHA224`, `SHA256`, `SHA384` or `SHA512`.
         :type authprotocol: None or str
         :param authpassword: Authorization password if authorization
             protocol is not `None`.
@@ -154,7 +154,11 @@ class Session:
                     None: cmdgen.usmNoAuthProtocol,
                     "MD5": cmdgen.usmHMACMD5AuthProtocol,
                     "SHA": cmdgen.usmHMACSHAAuthProtocol,
-                    "SHA1": cmdgen.usmHMACSHAAuthProtocol
+                    "SHA1": cmdgen.usmHMACSHAAuthProtocol,
+                    "SHA224": cmdgen.usmHMAC128SHA224AuthProtocol,
+                    "SHA256": cmdgen.usmHMAC192SHA256AuthProtocol,
+                    "SHA384": cmdgen.usmHMAC256SHA384AuthProtocol,
+                    "SHA512": cmdgen.usmHMAC384SHA512AuthProtocol,
                 }[authprotocol]
             except KeyError:
                 raise ValueError("{} is not an acceptable authentication "

--- a/tests/test_snmp.py
+++ b/tests/test_snmp.py
@@ -70,7 +70,7 @@ class TestSnmpSession(unittest.TestCase):
 
     def testSnmpV3Protocols(self):
         """Check accepted auth and privacy protocols"""
-        for auth in ["MD5", "SHA"]:
+        for auth in ["MD5", "SHA", "SHA224", "SHA256", "SHA384", "SHA512"]:
             for priv in ["AES", "AES128", "DES"]:
                 snmp.Session(host="localhost",
                              version=3,


### PR DESCRIPTION
The pysnmp library already supports these, so this is a matter of adding the needed mappings from authprotocol string to pysnmp constant.